### PR TITLE
Added connection pool capability

### DIFF
--- a/azure-kusto-data/azure/kusto/data/request.py
+++ b/azure-kusto-data/azure/kusto/data/request.py
@@ -2,9 +2,11 @@
 
 import uuid
 import json
+import urllib3
+import certifi
+
 from datetime import timedelta
 from enum import Enum, unique
-import requests
 
 from .security import _AadHelper
 from .exceptions import KustoServiceError
@@ -240,14 +242,21 @@ class KustoClient(object):
     _mgmt_default_timeout = timedelta(hours=1, seconds=30).seconds
     _query_default_timeout = timedelta(minutes=4, seconds=30).seconds
 
-    def __init__(self, kcsb):
+    def __init__(self, kcsb, max_pool_size=100):
         """Kusto Client constructor.
         :param kcsb: The connection string to initialize KustoClient.
         :type kcsb: azure.kusto.data.request.KustoConnectionStringBuilder or str
+        :param max_pool_size: The maximum amount of connections to open parallely
+        :type: int
         """
         if not isinstance(kcsb, KustoConnectionStringBuilder):
             kcsb = KustoConnectionStringBuilder(kcsb)
         kusto_cluster = kcsb.data_source
+
+        # Create a pool manager
+        self._pool_mgr = urllib3.PoolManager(num_pools=1, maxsize=max_pool_size,
+                                             cert_reqs='CERT_REQUIRED', ca_certs=certifi.where())
+
         self._mgmt_endpoint = "{0}/v1/rest/mgmt".format(kusto_cluster)
         self._query_endpoint = "{0}/v2/rest/query".format(kusto_cluster)
         self._auth_provider = _AadHelper(kcsb) if kcsb.aad_federated_security else None
@@ -303,14 +312,15 @@ class KustoClient(object):
             request_headers["Authorization"] = self._auth_provider.acquire_authorization_header()
 
         timeout = self._get_timeout(properties, default_timeout)
-        response = requests.post(endpoint, headers=request_headers, json=request_payload, timeout=timeout)
+        response = self._pool_mgr.request("POST", endpoint, headers=request_headers,
+                                          body=json.dumps(request_payload), timeout=timeout)
 
-        if response.status_code == 200:
+        if response.status == 200:
             if endpoint.endswith("v2/rest/query"):
-                return KustoResponseDataSetV2(response.json())
-            return KustoResponseDataSetV1(response.json())
+                return KustoResponseDataSetV2(json.loads(response.data))
+            return KustoResponseDataSetV1(json.loads(response.data))
 
-        raise KustoServiceError([response.json()], response)
+        raise KustoServiceError([json.loads(response.data)], response)
 
     def _get_timeout(self, properties, default):
         if properties:

--- a/azure-kusto-data/setup.py
+++ b/azure-kusto-data/setup.py
@@ -43,6 +43,6 @@ setup(
     ],
     keywords="kusto wrapper client library",
     packages=find_packages(exclude=["azure", "tests"]),
-    install_requires=["adal>=1.0.0", "python-dateutil>=2.7.0", "requests>=2.13.0", "six>=1.10.0"],
+    install_requires=["adal>=1.0.0", "python-dateutil>=2.7.0", "urllib3[secure]>=1.20", "six>=1.10.0"],
     extras_require={"pandas": ["pandas>=0.24.0"], ":python_version<'3.0'": ["azure-nspkg"]},
 )

--- a/azure-kusto-data/tests/test_kusto_client.py
+++ b/azure-kusto-data/tests/test_kusto_client.py
@@ -29,7 +29,7 @@ def mocked_poolmgr_request(*args, **kwargs):
     class MockResponse:
         """Mock class for KustoResponse."""
 
-        def __init__(self, json_data, status_code):
+        def __init__(self, data, status_code):
             self.data = data
             self.status = status_code
             self.headers = None

--- a/azure-kusto-data/tests/test_kusto_client.py
+++ b/azure-kusto-data/tests/test_kusto_client.py
@@ -23,42 +23,39 @@ except:
     pass
 
 
-def mocked_requests_post(*args, **kwargs):
-    """Mock to replace requests.post"""
+def mocked_poolmgr_request(*args, **kwargs):
+    """Mock to replace urllib3.PoolManager.request"""
 
     class MockResponse:
         """Mock class for KustoResponse."""
 
         def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.text = text_type(json_data)
-            self.status_code = status_code
+            self.data = data
+            self.status = status_code
             self.headers = None
 
-        def json(self):
-            """Get json data from response."""
-            return self.json_data
+    body_json = json.loads(kwargs["body"])
 
-    if args[0] == "https://somecluster.kusto.windows.net/v2/rest/query":
-        if "truncationmaxrecords" in kwargs["json"]["csl"]:
-            if json.loads(kwargs["json"]["properties"])["Options"]["deferpartialqueryfailures"]:
+    if args[1] == "https://somecluster.kusto.windows.net/v2/rest/query":
+        if "truncationmaxrecords" in body_json["csl"]:
+            if json.loads(body_json["properties"])["Options"]["deferpartialqueryfailures"]:
                 file_name = "query_partial_results_defer_is_true.json"
             else:
                 file_name = "query_partial_results_defer_is_false.json"
-        elif "Deft" in kwargs["json"]["csl"]:
+        elif "Deft" in body_json["csl"]:
             file_name = "deft.json"
         with open(os.path.join(os.path.dirname(__file__), "input", file_name), "r") as response_file:
             data = response_file.read()
-        return MockResponse(json.loads(data), 200)
+        return MockResponse(data, 200)
 
-    elif args[0] == "https://somecluster.kusto.windows.net/v1/rest/mgmt":
-        if kwargs["json"]["csl"] == ".show version":
+    elif args[1] == "https://somecluster.kusto.windows.net/v1/rest/mgmt":
+        if body_json["csl"] == ".show version":
             file_name = "versionshowcommandresult.json"
         else:
             file_name = "adminthenquery.json"
         with open(os.path.join(os.path.dirname(__file__), "input", file_name), "r") as response_file:
             data = response_file.read()
-        return MockResponse(json.loads(data), 200)
+        return MockResponse(data, 200)
 
     return MockResponse(None, 404)
 
@@ -81,7 +78,7 @@ DIGIT_WORDS = [
 class KustoClientTests(unittest.TestCase):
     """Tests class for KustoClient."""
 
-    @patch("requests.post", side_effect=mocked_requests_post)
+    @patch("urllib3.PoolManager.request", side_effect=mocked_poolmgr_request)
     def test_sanity_query(self, mock_post):
         """Test query V2."""
         client = KustoClient("https://somecluster.kusto.windows.net")
@@ -175,7 +172,7 @@ class KustoClientTests(unittest.TestCase):
             if expected["xint16"] > 0:
                 expected["xdynamicWithNulls"] = {"rowId": expected["xint16"], "arr": [0, expected["xint16"]]}
 
-    @patch("requests.post", side_effect=mocked_requests_post)
+    @patch("urllib3.PoolManager.request", side_effect=mocked_poolmgr_request)
     def test_sanity_control_command(self, mock_post):
         """Tests contol command."""
         client = KustoClient("https://somecluster.kusto.windows.net")
@@ -195,7 +192,7 @@ class KustoClientTests(unittest.TestCase):
         self.assertEqual(result["ProductVersion"], "KustoMain_2018.04.29.5")
 
     @pytest.mark.skipif(not pandas_installed, reason="requires pandas")
-    @patch("requests.post", side_effect=mocked_requests_post)
+    @patch("urllib3.PoolManager.request", side_effect=mocked_poolmgr_request)
     def test_sanity_data_frame(self, mock_post):
         """Tests KustoResponse to pandas.DataFrame."""
 
@@ -314,7 +311,7 @@ class KustoClientTests(unittest.TestCase):
         expected_data_frame = DataFrame(expected_dict, columns=columns, copy=True)
         assert_frame_equal(data_frame, expected_data_frame)
 
-    @patch("requests.post", side_effect=mocked_requests_post)
+    @patch("urllib3.PoolManager.request", side_effect=mocked_poolmgr_request)
     def test_partial_results(self, mock_post):
         """Tests partial results."""
         client = KustoClient("https://somecluster.kusto.windows.net")
@@ -332,7 +329,7 @@ range x from 1 to 10 step 1"""
         self.assertEqual(len(results), 5)
         self.assertEqual(results[0]["x"], 1)
 
-    @patch("requests.post", side_effect=mocked_requests_post)
+    @patch("urllib3.PoolManager.request", side_effect=mocked_poolmgr_request)
     def test_admin_then_query(self, mock_post):
         """Tests admin then query."""
         client = KustoClient("https://somecluster.kusto.windows.net")

--- a/azure-kusto-ingest/tests/test_kusto_ingest_client.py
+++ b/azure-kusto-ingest/tests/test_kusto_ingest_client.py
@@ -5,7 +5,6 @@ import json
 import base64
 from mock import patch
 from six import text_type
-import responses
 import io
 from azure.kusto.ingest import KustoIngestClient, IngestionProperties, DataFormat
 
@@ -26,8 +25,17 @@ BLOB_URL_REGEX = (
 )
 
 
-def request_callback(request):
-    body = json.loads(request.body.decode()) if type(request.body) == bytes else json.loads(request.body)
+def mocked_poolmgr_request(*args, **kwargs):
+
+    class MockResponse:
+        """Mock class for KustoResponse."""
+        def __init__(self, data, status_code, headers):
+            self.data = data
+            self.status = status_code
+            self.headers = headers
+            self.headers = None
+
+    body = json.loads(kwargs["body"].decode()) if type(kwargs["body"]) == bytes else json.loads(kwargs["body"])
     response_status = 400
     response_headers = []
     response_body = {}
@@ -91,7 +99,7 @@ def request_callback(request):
             ]
         }
 
-    return (response_status, response_headers, json.dumps(response_body))
+    return MockResponse(json.dumps(response_body), response_status, response_headers)
 
 
 class KustoIngestClientTests(unittest.TestCase):
@@ -99,21 +107,14 @@ class KustoIngestClientTests(unittest.TestCase):
     MOCKED_PID = 64
     MOCKED_TIME = 100
 
-    @responses.activate
     @patch("azure.kusto.data.security._AadHelper.acquire_authorization_header", return_value=None)
     @patch("azure.storage.blob.BlockBlobService.create_blob_from_stream")
     @patch("azure.storage.queue.QueueService.put_message")
+    @patch("urllib3.PoolManager.request", side_effect=mocked_poolmgr_request)
     @patch("uuid.uuid4", return_value=MOCKED_UUID_4)
     def test_sanity_ingest_from_file(
-        self, mock_uuid, mock_put_message_in_queue, mock_create_blob_from_stream, mock_aad
+        self, mock_uuid, mock_request, mock_put_message_in_queue, mock_create_blob_from_stream, mock_aad
     ):
-        responses.add_callback(
-            responses.POST,
-            "https://ingest-somecluster.kusto.windows.net/v1/rest/mgmt",
-            callback=request_callback,
-            content_type="application/json",
-        )
-
         ingest_client = KustoIngestClient("https://ingest-somecluster.kusto.windows.net")
         ingestion_properties = IngestionProperties(database="database", table="table", dataFormat=DataFormat.csv)
 
@@ -159,23 +160,17 @@ class KustoIngestClientTests(unittest.TestCase):
             == "database__table__1111-111111-111111-1111__dataset.csv.gz"
         )
 
-    @responses.activate
+
     @pytest.mark.skipif(not pandas_installed, reason="requires pandas")
     @patch("azure.storage.blob.BlockBlobService.create_blob_from_path")
     @patch("azure.storage.queue.QueueService.put_message")
+    @patch("urllib3.PoolManager.request", side_effect=mocked_poolmgr_request)
     @patch("uuid.uuid4", return_value=MOCKED_UUID_4)
     @patch("time.time", return_value=MOCKED_TIME)
     @patch("os.getpid", return_value=MOCKED_PID)
     def test_simple_ingest_from_dataframe(
-        self, mock_pid, mock_time, mock_uuid, mock_put_message_in_queue, mock_create_blob_from_path
+        self, mock_pid, mock_time, mock_uuid, mock_request, mock_put_message_in_queue, mock_create_blob_from_path
     ):
-        responses.add_callback(
-            responses.POST,
-            "https://ingest-somecluster.kusto.windows.net/v1/rest/mgmt",
-            callback=request_callback,
-            content_type="application/json",
-        )
-
         ingest_client = KustoIngestClient("https://ingest-somecluster.kusto.windows.net")
         ingestion_properties = IngestionProperties(database="database", table="table", dataFormat=DataFormat.csv)
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,4 @@
 pytest>=3.2.0
 mock>=2.0.0
-responses>=0.9.0
 pandas>=0.24.0
 black;python_version == '3.6'


### PR DESCRIPTION
Database connection pool reuses connections which are already open in a thread-safe way and therefore avoids TCP and TLS handshake for each query.
requests.post has been replaced with urllib3.PoolManager.request which manages the connection pool to a single server.
Requirement for requests>=2.13.0 has been replaced with urllib3[secure]>=1.20. There was a significant improvement in urllib 1.20 so it is the earliest version which has to be demanded. The [secure] flavor adds dependency in certifi which is used for TLS certification validation.