### PR TITLE
Update _models.py

### DIFF
--- a/azure-kusto-data/azure/kusto/data/_models.py
+++ b/azure-kusto-data/azure/kusto/data/_models.py
@@ -48,6 +48,8 @@ class KustoResultRow(object):
                 # There is current work being done to stay with the last, as this is the official representation for
                 # empty json. Once this work is done this if should be removed.
                 # The servers should not return empty string anymore as a valid json.
+            if lower_column_type == "dynamic" and isinstance(value, dict):
+                type_value = value
             elif lower_column_type in ["datetime", "timespan"]:
                 if value is None:
                     typed_value = None


### PR DESCRIPTION
Add additional case for properly handling returned dynamic data

When data is stored in a Kusto table as a dynamic type and is formatted properly then it is parsed by the response handler as a JSON object and not as a string object.
Checking this value for the column and checking if it is already a dynamic type prevents a error being thrown by the json module for passing a dict type to loads.