### PR TITLE
Fix bool of KustoResultTable

### DIFF
--- a/azure-kusto-data/azure/kusto/data/_models.py
+++ b/azure-kusto-data/azure/kusto/data/_models.py
@@ -137,6 +137,10 @@ class KustoResultTable(object):
     def columns_count(self):
         return len(self.columns)
 
+    def to_dict(self):
+        """Converts the table to a dict."""
+        return {"name": self.table_name, "kind": self.table_kind, "data": [r.to_dict() for r in self]}
+
     def __len__(self):
         return self.rows_count
 
@@ -147,11 +151,13 @@ class KustoResultTable(object):
     def __getitem__(self, key):
         return self.rows[key]
 
-    def to_dict(self):
-        return {"name": self.table_name, "kind": self.table_kind, "data": [r.to_dict() for r in self]}
-
     def __str__(self):
         d = self.to_dict()
         # enum is not serializable, using value instead
         d["kind"] = d["kind"].value
         return json.dumps(d)
+
+    def __bool__(self):
+        return any(self.columns)
+
+    __nonzero__ = __bool__

--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -16,9 +16,6 @@ def dataframe_from_result_table(table):
     if not isinstance(table, KustoResultTable):
         raise TypeError("Expected KustoResultTable got {}".format(type(table).__name__))
 
-    if not table.columns or not table.rows:
-        return pandas.DataFrame()
-
     frame = pandas.DataFrame.from_records(
         [row.to_list() for row in table.rows], columns=[col.column_name for col in table.columns]
     )

--- a/azure-kusto-data/tests/input/zero_results.json
+++ b/azure-kusto-data/tests/input/zero_results.json
@@ -1,0 +1,120 @@
+[{
+	"FrameType": "DataSetHeader",
+	"IsProgressive": false,
+	"Version": "v2.0"
+},
+{
+	"FrameType": "DataTable",
+	"TableId": 0,
+	"TableKind": "QueryProperties",
+	"TableName": "@ExtendedProperties",
+	"Columns": [{
+		"ColumnName": "TableId",
+		"ColumnType": "int"
+	},
+	{
+		"ColumnName": "Key",
+		"ColumnType": "string"
+	},
+	{
+		"ColumnName": "Value",
+		"ColumnType": "dynamic"
+	}],
+	"Rows": [[1,
+	"Visualization",
+	"{\"Visualization\":null,\"Title\":null,\"XColumn\":null,\"Series\":null,\"YColumns\":null,\"AnomalyColumns\":null,\"XTitle\":null,\"YTitle\":null,\"XAxis\":null,\"YAxis\":null,\"Legend\":null,\"YSplit\":null,\"Accumulate\":false,\"IsQuerySorted\":false,\"Kind\":null,\"Ymin\":\"NaN\",\"Ymax\":\"NaN\"}"]]
+},
+{
+	"FrameType": "DataTable",
+	"TableId": 1,
+	"TableKind": "PrimaryResult",
+	"TableName": "PrimaryResult",
+	"Columns": [{
+		"ColumnName": "print_0",
+		"ColumnType": "string"
+	}],
+	"Rows": []
+},
+{
+	"FrameType": "DataTable",
+	"TableId": 2,
+	"TableKind": "QueryCompletionInformation",
+	"TableName": "QueryCompletionInformation",
+	"Columns": [{
+		"ColumnName": "Timestamp",
+		"ColumnType": "datetime"
+	},
+	{
+		"ColumnName": "ClientRequestId",
+		"ColumnType": "string"
+	},
+	{
+		"ColumnName": "ActivityId",
+		"ColumnType": "guid"
+	},
+	{
+		"ColumnName": "SubActivityId",
+		"ColumnType": "guid"
+	},
+	{
+		"ColumnName": "ParentActivityId",
+		"ColumnType": "guid"
+	},
+	{
+		"ColumnName": "Level",
+		"ColumnType": "int"
+	},
+	{
+		"ColumnName": "LevelName",
+		"ColumnType": "string"
+	},
+	{
+		"ColumnName": "StatusCode",
+		"ColumnType": "int"
+	},
+	{
+		"ColumnName": "StatusCodeName",
+		"ColumnType": "string"
+	},
+	{
+		"ColumnName": "EventType",
+		"ColumnType": "int"
+	},
+	{
+		"ColumnName": "EventTypeName",
+		"ColumnType": "string"
+	},
+	{
+		"ColumnName": "Payload",
+		"ColumnType": "string"
+	}],
+	"Rows": [["2019-02-12T10:23:02.0413963Z",
+	"KPC.execute;57050c90-8a7d-4b29-b8d0-a40688a8185c",
+	"dfbaa865-e29d-46e0-af17-be22c6c113ac",
+	"e2bf7a6c-adf1-48da-b117-667a92874d38",
+	"81409d63-718b-4d06-9711-7eab476b7ceb",
+	4,
+	"Info",
+	0,
+	"S_OK (0)",
+	4,
+	"QueryInfo",
+	"{\"Count\":1,\"Text\":\"Querycompletedsuccessfully\"}"],
+	["2019-02-12T10:23:02.0413963Z",
+	"KPC.execute;57050c90-8a7d-4b29-b8d0-a40688a8185c",
+	"dfbaa865-e29d-46e0-af17-be22c6c113ac",
+	"e2bf7a6c-adf1-48da-b117-667a92874d38",
+	"81409d63-718b-4d06-9711-7eab476b7ceb",
+	6,
+	"Stats",
+	0,
+	"S_OK (0)",
+	0,
+	"QueryResourceConsumption",
+	"{\"ExecutionTime\":0.0156475,\"resource_usage\":{\"cache\":{\"memory\":{\"hits\":0,\"misses\":0,\"total\":0},\"disk\":{\"hits\":0,\"misses\":0,\"total\":0},\"shards\":{\"hitbytes\":0,\"missbytes\":0,\"bypassbytes\":0}},\"cpu\":{\"user\":\"00: 00: 00\",\"kernel\":\"00: 00: 00\",\"totalcpu\":\"00: 00: 00\"},\"memory\":{\"peak_per_node\":0}},\"input_dataset_statistics\":{\"extents\":{\"total\":0,\"scanned\":0},\"rows\":{\"total\":0,\"scanned\":0},\"rowstores\":{\"scanned_rows\":0,\"scanned_values_size\":0}},\"dataset_statistics\":[{\"table_row_count\":0,\"table_size\":0}]}"]]
+},
+{
+	"FrameType": "DataSetCompletion",
+	"HasErrors": false,
+	"Cancelled": false
+}]

--- a/azure-kusto-data/tests/test_kusto_client.py
+++ b/azure-kusto-data/tests/test_kusto_client.py
@@ -46,6 +46,8 @@ def mocked_poolmgr_request(*args, **kwargs):
             file_name = "deft.json"
         elif "print dynamic" in body_json["csl"]:
             file_name = "dynamic.json"
+        elif "take 0" in body_json["csl"]:
+            file_name = "zero_results.json"
         with open(os.path.join(os.path.dirname(__file__), "input", file_name), "r") as response_file:
             data = response_file.read()
         return MockResponse(data.encode("UTF-8"), 200)
@@ -368,3 +370,11 @@ range x from 1 to 10 step 1"""
 
         self.assertIsInstance(row[5], dict)
         self.assertEqual(row[5], {"rowId": 2, "arr": [0, 2]})
+
+    @patch("urllib3.PoolManager.request", side_effect=mocked_poolmgr_request)
+    def test_empty_result(self, mock_post):
+        """Tests dynamic responses."""
+        client = KustoClient("https://somecluster.kusto.windows.net")
+        query = """print 'a' | take 0"""
+        response = client.execute_query("PythonTest", query)
+        self.assertTrue(response.primary_results[0])


### PR DESCRIPTION
Apparently when checking `if object:` than the method that is called to know if the object represents true or false, is `__bool__` in python 3 and above, and `__nonzero__` in python 2.7 .
Since the `__bool__` method was not defined, there is a fallback to `__len__`, which is 0, therefore [this condition](https://github.com/Azure/azure-kusto-python/blob/6db20a4719e8fb691ba39e65b95e9558f88ae382/azure-kusto-data/azure/kusto/data/helpers.py#L13) was false, and DataFrame was not created.
[Here](https://docs.python.org/3.7/reference/datamodel.html#object.__bool__) is a link that supports my claims.
As the object is valid, and the columns exists, we want to enable converting to an empty DataFrame.
Thanks to @miflower for reporting about this issue.