### PR TITLE
Compress stream before sending

### DIFF
--- a/azure-kusto-data/azure/kusto/data/request.py
+++ b/azure-kusto-data/azure/kusto/data/request.py
@@ -445,6 +445,7 @@ class KustoClient(object):
             request_headers["x-ms-client-request-id"] = "KPC.execute;" + str(uuid.uuid4())
         else:
             request_headers["x-ms-client-request-id"] = "KPC.execute_streaming_ingest;" + str(uuid.uuid4())
+            request_headers["Content-Encoding"] = "gzip"
             if properties:
                 request_headers.update(json.loads(properties.to_json())["Options"])
 

--- a/azure-kusto-ingest/azure/kusto/ingest/__init__.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/__init__.py
@@ -14,6 +14,6 @@ from ._ingestion_properties import (
     JsonColumnMapping,
     IngestionProperties,
 )
-from .exceptions import KustoStreamMaxSizeExceededError, KustoMissingMappingReferenceError
+from .exceptions import KustoMissingMappingReferenceError
 
 from ._version import VERSION as __version__

--- a/azure-kusto-ingest/azure/kusto/ingest/_descriptors.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_descriptors.py
@@ -81,22 +81,16 @@ class BlobDescriptor(object):
 class StreamDescriptor(object):
     """StreamDescriptor is used to describe a stream that will be used as ingestion source"""
 
-    def __init__(self, stream, size=None, source_id=None, is_zipped_stream=False):
+    def __init__(self, stream, source_id=None, is_compressed=False):
         """
         :param stream: in-memory stream object.
         :type stream: io.BaseIO
-        :param size: size of the provided stream.
-        :type: size: int
         :param source_id: a v4 uuid to serve as the sources id.
         :type source_id: str (of a uuid4) or uuid4.
+        :param is_compressed: specify if the provided stream is compressed
+        :type is_compressed: boolean
         """
         self.stream = stream
-        if size is None:
-            stream.seek(0, SEEK_END)
-            size = stream.tell()
-            stream.seek(0, SEEK_SET)
-
-        self.size = size
         assert_uuid4(source_id, "source_id must be a valid uuid4")
         self.source_id = source_id
-        self.is_zipped_stream = is_zipped_stream
+        self.is_compressed = is_compressed

--- a/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
@@ -97,7 +97,7 @@ class KustoStreamingIngestClient(object):
             buffer = stream.read()
             with GzipFile(filename="data", fileobj=zipped_stream, mode="wb") as f_out:
                 if isinstance(buffer, string_types):
-                    data = bytes(buffer) if PY2 else bytes(buffer, 'utf-8')
+                    data = bytes(buffer) if PY2 else bytes(buffer, "utf-8")
                     f_out.write(data)
                 else:
                     f_out.write(buffer)

--- a/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
@@ -109,6 +109,5 @@ class KustoStreamingIngestClient(object):
             ingestion_properties.table,
             stream,
             ingestion_properties.format.name,
-            None,
-            ingestion_properties.mapping_reference,
+            mapping_name=ingestion_properties.mapping_reference,
         )

--- a/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
@@ -97,7 +97,7 @@ class KustoStreamingIngestClient(object):
             buffer = stream.read()
             with GzipFile(filename="data", fileobj=zipped_stream, mode="wb") as f_out:
                 if isinstance(buffer, string_types):
-				    data = bytes(buffer) if PY2 else bytes(data, 'utf8')
+				    data = bytes(buffer) if PY2 else bytes(buffer, 'utf8')
                     f_out.write(data)
                 else:
                     f_out.write(buffer)

--- a/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
@@ -97,7 +97,7 @@ class KustoStreamingIngestClient(object):
             buffer = stream.read()
             with GzipFile(filename="data", fileobj=zipped_stream, mode="wb") as f_out:
                 if isinstance(buffer, string_types):
-				    data = bytes(buffer) if PY2 else bytes(buffer, 'utf8')
+                    data = bytes(buffer) if PY2 else bytes(buffer, 'utf-8')
                     f_out.write(data)
                 else:
                     f_out.write(buffer)

--- a/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
@@ -95,7 +95,7 @@ class KustoStreamingIngestClient(object):
             zipped_stream = BytesIO()
             buffer = stream.read()
             with GzipFile(filename="data", fileobj=zipped_stream, mode="wb") as f_out:
-                if isinstance(buffer, str):
+                if isinstance(buffer, basestring):
                     f_out.write(bytes(buffer, "utf-8"))
                 else:
                     f_out.write(buffer)

--- a/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
@@ -2,15 +2,13 @@
 import os
 import time
 import tempfile
+from gzip import GzipFile
 
 from azure.kusto.data.request import KustoClient, ClientRequestProperties
 from ._descriptors import FileDescriptor, StreamDescriptor
-from .exceptions import KustoMissingMappingReferenceError, KustoStreamMaxSizeExceededError
+from .exceptions import KustoMissingMappingReferenceError
 from ._ingestion_properties import DataFormat
-from io import TextIOWrapper
-
-_1KB = 1024
-_1MB = _1KB * _1KB
+from io import TextIOWrapper, BytesIO
 
 
 class KustoStreamingIngestClient(object):
@@ -21,7 +19,6 @@ class KustoStreamingIngestClient(object):
     """
 
     _mapping_required_formats = [DataFormat.json, DataFormat.singlejson, DataFormat.avro]
-    _streaming_ingestion_size_limit = 4 * _1MB
 
     def __init__(self, kcsb):
         """Kusto Streaming Ingest Client constructor.
@@ -49,7 +46,7 @@ class KustoStreamingIngestClient(object):
 
         ingestion_properties.format = DataFormat.csv
 
-        stream_descriptor = StreamDescriptor(fd.zipped_stream, fd.size, fd.source_id, True)
+        stream_descriptor = StreamDescriptor(fd.zipped_stream, fd.source_id, True)
 
         self.ingest_from_stream(stream_descriptor, ingestion_properties)
 
@@ -67,7 +64,7 @@ class KustoStreamingIngestClient(object):
         else:
             descriptor = FileDescriptor(file_descriptor)
 
-        stream_descriptor = StreamDescriptor(descriptor.zipped_stream, descriptor.size, descriptor.source_id, True)
+        stream_descriptor = StreamDescriptor(descriptor.zipped_stream, descriptor.source_id, True)
 
         self.ingest_from_stream(stream_descriptor, ingestion_properties)
 
@@ -88,27 +85,30 @@ class KustoStreamingIngestClient(object):
         else:
             stream = stream_descriptor.stream
 
-        if stream_descriptor.size >= self._streaming_ingestion_size_limit:
-            raise KustoStreamMaxSizeExceededError()
-
         if (
             ingestion_properties.format in self._mapping_required_formats
             and ingestion_properties.mapping_reference is None
         ):
             raise KustoMissingMappingReferenceError()
 
-        client_request_properties = ClientRequestProperties()
-        client_request_properties.set_option("content_length", str(stream_descriptor.size))
-        if stream_descriptor.source_id:
-            client_request_properties.set_option("x-ms-client-request-id", str(stream_descriptor.source_id))
-        if stream_descriptor.is_zipped_stream:
-            client_request_properties.set_option("Content-Encoding", "gzip")
+        if not stream_descriptor.is_compressed:
+            zipped_stream = BytesIO()
+            buffer = stream.read()
+            with GzipFile(
+                filename="data", fileobj=zipped_stream, mode="wb"
+            ) as f_out:
+                if isinstance(buffer, str):
+                    f_out.write(bytes(buffer, "utf-8"))
+                else:
+                    f_out.write(buffer)
+            zipped_stream.seek(0)
+            stream = zipped_stream
 
         self._kusto_client.execute_streaming_ingest(
             ingestion_properties.database,
             ingestion_properties.table,
             stream,
             ingestion_properties.format.name,
-            client_request_properties,
+            None,
             ingestion_properties.mapping_reference,
         )

--- a/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
@@ -9,7 +9,7 @@ from ._descriptors import FileDescriptor, StreamDescriptor
 from .exceptions import KustoMissingMappingReferenceError
 from ._ingestion_properties import DataFormat
 from io import TextIOWrapper, BytesIO
-from six import string_types
+from six import string_types, PY2
 
 
 class KustoStreamingIngestClient(object):
@@ -97,7 +97,8 @@ class KustoStreamingIngestClient(object):
             buffer = stream.read()
             with GzipFile(filename="data", fileobj=zipped_stream, mode="wb") as f_out:
                 if isinstance(buffer, string_types):
-                    f_out.write(bytes(buffer, "utf-8"))
+				    data = bytes(buffer) if PY2 else bytes(data, 'utf8')
+                    f_out.write(data)
                 else:
                     f_out.write(buffer)
             zipped_stream.seek(0)

--- a/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
@@ -94,9 +94,7 @@ class KustoStreamingIngestClient(object):
         if not stream_descriptor.is_compressed:
             zipped_stream = BytesIO()
             buffer = stream.read()
-            with GzipFile(
-                filename="data", fileobj=zipped_stream, mode="wb"
-            ) as f_out:
+            with GzipFile(filename="data", fileobj=zipped_stream, mode="wb") as f_out:
                 if isinstance(buffer, str):
                     f_out.write(bytes(buffer, "utf-8"))
                 else:

--- a/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_streaming_ingest_client.py
@@ -9,6 +9,7 @@ from ._descriptors import FileDescriptor, StreamDescriptor
 from .exceptions import KustoMissingMappingReferenceError
 from ._ingestion_properties import DataFormat
 from io import TextIOWrapper, BytesIO
+from six import string_types
 
 
 class KustoStreamingIngestClient(object):
@@ -95,7 +96,7 @@ class KustoStreamingIngestClient(object):
             zipped_stream = BytesIO()
             buffer = stream.read()
             with GzipFile(filename="data", fileobj=zipped_stream, mode="wb") as f_out:
-                if isinstance(buffer, basestring):
+                if isinstance(buffer, string_types):
                     f_out.write(bytes(buffer, "utf-8"))
                 else:
                     f_out.write(buffer)

--- a/azure-kusto-ingest/azure/kusto/ingest/exceptions.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/exceptions.py
@@ -14,16 +14,6 @@ class KustoDuplicateMappingError(KustoClientError):
         super(KustoDuplicateMappingError, self).__init__(message)
 
 
-class KustoStreamMaxSizeExceededError(KustoClientError):
-    """
-    Error to be raised when stream is too big for streaming ingest
-    """
-
-    def __init__(self):
-        message = "The provided stream exceeded the maximum allowed size for streaming ingest"
-        super(KustoStreamMaxSizeExceededError, self).__init__(message)
-
-
 class KustoMissingMappingReferenceError(KustoClientError):
     """
     Error to be raised when ingestion properties has data format of Json, SingleJson, MultiJson or Avro

--- a/azure-kusto-ingest/tests/test_kusto_streaming_ingest_client.py
+++ b/azure-kusto-ingest/tests/test_kusto_streaming_ingest_client.py
@@ -1,11 +1,10 @@
-import pytest
 import os
 import unittest
 import json
 import responses
 import io
 from azure.kusto.ingest import KustoStreamingIngestClient, IngestionProperties, DataFormat
-from azure.kusto.ingest.exceptions import KustoMissingMappingReferenceError, KustoStreamMaxSizeExceededError
+from azure.kusto.ingest.exceptions import KustoMissingMappingReferenceError
 
 
 pandas_installed = False


### PR DESCRIPTION
Compressing stream before uploading it to reduce network time. 
Remove size check from the client - will get error from the server.