### PR TITLE
adding support for _AadHelper pickling

### DIFF
--- a/azure-kusto-data/azure/kusto/data/request.py
+++ b/azure-kusto-data/azure/kusto/data/request.py
@@ -482,6 +482,20 @@ class ClientRequestProperties(object):
 
     def __init__(self):
         self._options = {}
+        self._parameters = {}
+
+    def set_parameter(self, name, value):
+        """Sets a parameter's value"""
+        _assert_value_is_valid(name)
+        self._parameters[name] = value
+
+    def has_parameter(self, name):
+        """Checks if a parameter is specified."""
+        return name in self._parameters
+
+    def get_parameter(self, name, default_value):
+        """Gets a parameter's value."""
+        return self._parameters.get(name, default_value)
 
     def set_option(self, name, value):
         """Sets an option's value"""
@@ -498,4 +512,4 @@ class ClientRequestProperties(object):
 
     def to_json(self):
         """Safe serialization to a JSON string."""
-        return json.dumps({"Options": self._options}, default=str)
+        return json.dumps({"Options": self._options, "Parameters": self._parameters}, default=str)

--- a/azure-kusto-data/tests/sample.py
+++ b/azure-kusto-data/tests/sample.py
@@ -41,7 +41,7 @@ password = "<password>"
 kcsb = KustoConnectionStringBuilder.with_aad_user_password_authentication(cluster, username, password, authority_id)
 
 # In case you want to authenticate with AAD device code.
-# Please note that if you choose this option, you'll need to autenticate for every new instance that is initialized.
+# Please note that if you choose this option, you'll need to authenticate for every new instance that is initialized.
 # It is highly recommended to create one instance and use it for all of your queries.
 kcsb = KustoConnectionStringBuilder.with_aad_device_authentication(cluster)
 

--- a/azure-kusto-data/tests/test_security.py
+++ b/azure-kusto-data/tests/test_security.py
@@ -1,5 +1,5 @@
 """Tests for security module."""
-
+import pickle
 from azure.kusto.data.exceptions import KustoAuthenticationError
 from azure.kusto.data.request import KustoConnectionStringBuilder
 from azure.kusto.data.security import _AadHelper, AuthenticationMethod
@@ -22,3 +22,14 @@ def test_unauthorized_exception():
         assert error.authority == "https://login.microsoftonline.com/authorityName"
         assert error.kusto_cluster == cluster
         assert error.kwargs["username"] == username
+
+def test_pickle():
+    """_AadHelper needs to be serializeable"""
+    cluster = "https://somecluster.kusto.windows.net"
+    username = "username@microsoft.com"
+    kcsb = KustoConnectionStringBuilder.with_aad_user_password_authentication(
+        cluster, username, "StrongestPasswordEver", "authorityName")
+    helper = _AadHelper(kcsb)
+    p = pickle.dumps(helper)
+    restored_helper = pickle.loads(p)
+    assert restored_helper._kusto_cluster == cluster


### PR DESCRIPTION
In my we would like users to authenticate with aad device codes once, then make parallel kusto queries using the same client. 
A natural way to do this is via a pool map function. 
This revision allows _AadHelper to serialize via pickle.dump used by the multiprocessing libraries. 