### PR TITLE
Remove unnecessary lines from dataframe helper function

### DIFF
--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -47,4 +47,9 @@ def dataframe_from_result_table(table):
     columns = [col.column_name for col in table.columns]
     frame = pd.DataFrame(table._rows, columns=columns)
 
+    # fix types
+    for col in table.columns:
+        if col.column_type == "bool":
+            frame[col.column_name] = frame[col.column_name].astype(bool)
+
     return frame

--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -32,7 +32,6 @@ def to_pandas_timedelta(raw_value, timedelta_value):
 def dataframe_from_result_table(table):
     import pandas as pd
     from ._models import KustoResultTable
-    from dateutil.tz import UTC
 
     """Converts Kusto tables into pandas DataFrame.
     :param azure.kusto.data._models.KustoResultTable table: Table received from the response.
@@ -47,10 +46,5 @@ def dataframe_from_result_table(table):
 
     columns = [col.column_name for col in table.columns]
     frame = pd.DataFrame(table._rows, columns=columns)
-
-    # fix types
-    for col in table.columns:
-        if col.column_type == "bool":
-            frame[col.column_name] = frame[col.column_name].astype(bool)
 
     return frame


### PR DESCRIPTION
- `dateutil.tz.UTC` is never used - looks like an artifact from a removed check for datetime.
- Seems like bool data type is already handled correctly in `KustoResultTable`.