### PR TITLE
Fix MSI Auth

### DIFF
--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -218,7 +218,7 @@ def _get_header_from_dict(token: dict):
         # Assume OAuth2 format (e.g. MSI Token)
         return _get_header(token[OAuth2ResponseParameters.TOKEN_TYPE], token[OAuth2ResponseParameters.ACCESS_TOKEN])
     else:
-        raise KustoClientError("Unexpected token format!")
+        raise KustoClientError("Unable to determine the token type. Neither 'tokenType' nor 'token_type' property is present.")
 
 
 def _get_header(token_type, access_token):


### PR DESCRIPTION
MSI tokens are using OAuth2 format while code seems to work using a different format.
Fixed _AadHelper._get_header_from_dict() to implicitly support OAuth2 token formats