### PR TITLE
Restore compatibility with dateutil 2.7.x

### DIFF
--- a/azure-kusto-data/azure/kusto/data/_converters.py
+++ b/azure-kusto-data/azure/kusto/data/_converters.py
@@ -7,13 +7,21 @@ from dateutil import parser
 
 # Regex for TimeSpan
 _TIMESPAN_PATTERN = re.compile(r"(-?)((?P<d>[0-9]*).)?(?P<h>[0-9]{2}):(?P<m>[0-9]{2}):(?P<s>[0-9]{2}(\.[0-9]+)?$)")
+_MICROSECONDS_PATTERN = re.compile(r"(.*\.[0-9]{0,6})[0-9]*([A-Z]*)")
 
 
 def to_datetime(value):
     """Converts a string to a datetime."""
     if isinstance(value, int):
         return parser.parse(value)
-    return parser.isoparse(value)
+    # Until v2.8.0 dateutil does not support more than 6 digits for fractional seconds
+    try:
+        return parser.isoparse(value)
+    except ValueError:
+        match = _MICROSECONDS_PATTERN.match(value)
+        if match:
+            value = match.group(1) + match.group(2)
+        return parser.isoparse(value)
 
 
 def to_timedelta(value):

--- a/azure-kusto-data/setup.py
+++ b/azure-kusto-data/setup.py
@@ -41,6 +41,6 @@ setup(
     namespace_packages=["azure"],
     keywords="kusto wrapper client library",
     packages=find_packages(exclude=["azure", "tests"]),
-    install_requires=["adal>=1.0.0", "python-dateutil>=2.8.0", "requests>=2.13.0", "msrestazure>=0.4.14"],
+    install_requires=["adal>=1.0.0", "python-dateutil>=2.7.0", "requests>=2.13.0", "msrestazure>=0.4.14"],
     extras_require={"pandas": ["pandas==0.24.1"], ":python_version<'3.0'": ["azure-nspkg"]},
 )


### PR DESCRIPTION
#### Pull Request Description

Many distributions are using dateutil 2.7.x, including Debian stable.
Restore compatibility by truncating timestamps with a precision of
more than a microsecond.

---

#### Future Release Comment

**Fixes:**
- Restore compatibility with dateutil 2.7.x