### PR TITLE
Rasie exception when az cli token not found - Closes #240

### DIFF
--- a/azure-kusto-data/azure/kusto/data/exceptions.py
+++ b/azure-kusto-data/azure/kusto/data/exceptions.py
@@ -43,9 +43,11 @@ class KustoAuthenticationError(KustoClientError):
     def __init__(self, authentication_method: str, exception: Exception, **kwargs):
         super().__init__()
         self.authentication_method = authentication_method
-        self.authority = kwargs["authority"]
-        self.kusto_cluster = kwargs["resource"]
         self.exception = exception
+        if "authority" in kwargs:
+            self.authority = kwargs["authority"]
+        if "resource" in kwargs:
+            self.kusto_cluster = kwargs["resource"]
         self.kwargs = kwargs
 
     def __str__(self):

--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -48,9 +48,7 @@ def _get_azure_cli_auth_token() -> dict:
             # TODO: not sure I should take the first
             return data[0]
         except Exception as e:
-            raise KustoAuthenticationError(
-                AuthenticationMethod.az_cli_profile, e, message="Azure cli token was not found. Please run 'az login' to setup account."
-            )
+            raise KustoClientError("Azure cli token was not found. Please run 'az login' to setup account.", e)
 
 
 @unique
@@ -152,6 +150,8 @@ class _AadHelper:
                 kwargs["authority"] = AuthenticationMethod.token_provider.value
             elif self.auth_context is not None:
                 kwargs["authority"] = self.auth_context.authority.url
+            elif self.authentication_method is AuthenticationMethod.az_cli_profile:
+                kwargs["authority"] = AuthenticationMethod.az_cli_profile.value
 
             raise KustoAuthenticationError(self.authentication_method.value, error, **kwargs)
 

--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -47,8 +47,10 @@ def _get_azure_cli_auth_token() -> dict:
 
             # TODO: not sure I should take the first
             return data[0]
-        except Exception:
-            pass
+        except Exception as e:
+            raise KustoAuthenticationError(
+                AuthenticationMethod.az_cli_profile, e, message="Azure cli token was not found. Please run 'az login' to setup account."
+            )
 
 
 @unique


### PR DESCRIPTION
#### Pull Request Description

Raise descriptive exception when az cli token not found when using az cli authentication.
---

#### Future Release Comment

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Raise descriptive exception when az cli token not found when using az cli authentication.