### PR TITLE
Switch from msrestazure to azure.identity to obtain MSI Tokens

### DIFF
--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -314,19 +314,21 @@ class KustoConnectionStringBuilder:
             exclusive_pcount += 1
 
         if object_id is not None:
-            # Until we upgarde azure-identity to version 1.4.1, only client_id is excepted as a hint for user managed service identity
-            raise ValueError("User Managed Service Identity with object_id is temporarily not supported by azure identity 1.3.1")
+            # Until we upgrade azure-identity to version 1.4.1, only client_id is excepted as a hint for user managed service identity
+            raise ValueError("User Managed Service Identity with object_id is temporarily not supported by azure identity 1.3.1."
+                             " Please use client_id instead.")
             params["object_id"] = object_id
             exclusive_pcount += 1
 
         if msi_res_id is not None:
-            # Until we upgarde azure-identity to version 1.4.1, only client_id is excepted as a hint for user managed service identity
-            raise ValueError("User Managed Service Identity with msi_res_id is temporarily not supported by azure identity 1.3.1")
+            # Until we upgrade azure-identity to version 1.4.1, only client_id is excepted as a hint for user managed service identity
+            raise ValueError("User Managed Service Identity with msi_res_id is temporarily not supported by azure identity 1.3.1."
+                             " Please use client_id instead.")
             params["msi_res_id"] = msi_res_id
             exclusive_pcount += 1
 
         if exclusive_pcount > 1:
-            raise ValueError("the following parameters are mutually exclusive and can not be provided at the same time: user_uid, object_id, msi_res_id")
+            raise ValueError("the following parameters are mutually exclusive and can not be provided at the same time: client_uid, object_id, msi_res_id")
 
         kcsb[kcsb.ValidKeywords.aad_federated_security] = True
         kcsb[kcsb.ValidKeywords.msi_auth] = True

--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -315,15 +315,15 @@ class KustoConnectionStringBuilder:
 
         if object_id is not None:
             # Until we upgrade azure-identity to version 1.4.1, only client_id is excepted as a hint for user managed service identity
-            raise ValueError("User Managed Service Identity with object_id is temporarily not supported by azure identity 1.3.1."
-                             " Please use client_id instead.")
+            raise ValueError("User Managed Service Identity with object_id is temporarily not supported by azure identity 1.3.1. Please use client_id instead.")
             params["object_id"] = object_id
             exclusive_pcount += 1
 
         if msi_res_id is not None:
             # Until we upgrade azure-identity to version 1.4.1, only client_id is excepted as a hint for user managed service identity
-            raise ValueError("User Managed Service Identity with msi_res_id is temporarily not supported by azure identity 1.3.1."
-                             " Please use client_id instead.")
+            raise ValueError(
+                "User Managed Service Identity with msi_res_id is temporarily not supported by azure identity 1.3.1. Please use client_id instead."
+            )
             params["msi_res_id"] = msi_res_id
             exclusive_pcount += 1
 

--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -303,21 +303,25 @@ class KustoConnectionStringBuilder:
         """
 
         kcsb = cls(connection_string)
-        params = {"resource": kcsb.data_source}
+        params = {}
         exclusive_pcount = 0
 
         if timeout is not None:
-            params["timeout"] = timeout
+            params["connection_timeout"] = timeout
 
         if client_id is not None:
             params["client_id"] = client_id
             exclusive_pcount += 1
 
         if object_id is not None:
+            # Until we upgarde azure-identity to version 1.4.1, only client_id is excepted as a hint for user managed service identity
+            raise ValueError("User Managed Service Identity with object_id is temporarily not supported by azure identity 1.3.1")
             params["object_id"] = object_id
             exclusive_pcount += 1
 
         if msi_res_id is not None:
+            # Until we upgarde azure-identity to version 1.4.1, only client_id is excepted as a hint for user managed service identity
+            raise ValueError("User Managed Service Identity with msi_res_id is temporarily not supported by azure identity 1.3.1")
             params["msi_res_id"] = msi_res_id
             exclusive_pcount += 1
 

--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 import dateutil.parser
 from adal import AuthenticationContext, AdalError
 from adal.constants import TokenResponseFields, OAuth2DeviceCodeResponseParameters, OAuth2ResponseParameters
-from msrestazure.azure_active_directory import MSIAuthentication
+from azure.identity import ManagedIdentityCredential
 
 from .exceptions import KustoClientError, KustoAuthenticationError
 
@@ -60,7 +60,7 @@ class AuthenticationMethod(Enum):
     aad_application_certificate = "aad_application_certificate"
     aad_device_login = "aad_device_login"
     aad_token = "aad_token"
-    aad_msi = "aad_msi"
+    managed_service_identity = "managed_service_identity"
     az_cli_profile = "az_cli_profile"
     token_provider = "token_provider"
 
@@ -101,7 +101,7 @@ class _AadHelper:
             self.certificate = kcsb.application_certificate
             self.thumbprint = kcsb.application_certificate_thumbprint
         elif kcsb.msi_authentication:
-            self.authentication_method = AuthenticationMethod.aad_msi
+            self.authentication_method = AuthenticationMethod.managed_service_identity
             self.msi_params = kcsb.msi_parameters
             return
         elif any([kcsb.user_token, kcsb.application_token]):
@@ -135,7 +135,7 @@ class _AadHelper:
                 kwargs = {"client_id": self.client_id}
             elif self.authentication_method is AuthenticationMethod.aad_application_certificate:
                 kwargs = {"client_id": self.client_id, "thumbprint": self.thumbprint}
-            elif self.authentication_method is AuthenticationMethod.aad_msi:
+            elif self.authentication_method is AuthenticationMethod.managed_service_identity:
                 kwargs = self.msi_params
             elif self.authentication_method is AuthenticationMethod.token_provider:
                 kwargs = {}
@@ -144,8 +144,8 @@ class _AadHelper:
 
             kwargs["resource"] = self.kusto_uri
 
-            if self.authentication_method is AuthenticationMethod.aad_msi:
-                kwargs["authority"] = AuthenticationMethod.aad_msi.value
+            if self.authentication_method is AuthenticationMethod.managed_service_identity:
+                kwargs["authority"] = AuthenticationMethod.managed_service_identity.value
             elif self.authentication_method is AuthenticationMethod.token_provider:
                 kwargs["authority"] = AuthenticationMethod.token_provider.value
             elif self.auth_context is not None:
@@ -166,7 +166,7 @@ class _AadHelper:
             return _get_header("Bearer", caller_token)
 
         # Obtain token from MSI endpoint
-        if self.authentication_method == AuthenticationMethod.aad_msi:
+        if self.authentication_method == AuthenticationMethod.managed_service_identity:
             token = self.get_token_from_msi()
             return _get_header_from_dict(token)
 
@@ -222,16 +222,13 @@ class _AadHelper:
     def get_token_from_msi(self) -> dict:
         try:
             if self.msi_auth_context is None:
-                # Create the MSI Authentication object, the first token is acquired implicitly
-                self.msi_auth_context = MSIAuthentication(**self.msi_params)
-            else:
-                # Acquire a fresh token
-                self.msi_auth_context.set_token()
+                # Create the MSI Authentication object
+                self.msi_auth_context = ManagedIdentityCredential(**self.msi_params)
+
+            return self.msi_auth_context.get_token(self.kusto_uri)
 
         except Exception as e:
             raise KustoClientError("Failed to obtain MSI context for [" + str(self.msi_params) + "]\n" + str(e))
-
-        return self.msi_auth_context.token
 
 
 def _get_header_from_dict(token: dict):

--- a/azure-kusto-data/setup.py
+++ b/azure-kusto-data/setup.py
@@ -43,6 +43,6 @@ setup(
     namespace_packages=["azure"],
     keywords="kusto wrapper client library",
     packages=find_packages(exclude=["azure", "tests"]),
-    install_requires=["adal>=1.0.0", "python-dateutil>=2.8.0", "requests>=2.13.0", "msrestazure>=0.4.14"],
+    install_requires=["adal>=1.0.0", "python-dateutil>=2.8.0", "requests>=2.13.0", "azure.identity>=1.3.1"],
     extras_require={"pandas": ["pandas"]},
 )

--- a/azure-kusto-data/tests/sample.py
+++ b/azure-kusto-data/tests/sample.py
@@ -33,6 +33,13 @@ with open(filename, "r") as pem_file:
 thumbprint = "certificate's thumbprint"
 kcsb = KustoConnectionStringBuilder.with_aad_application_certificate_authentication(cluster, client_id, PEM, thumbprint, authority_id)
 
+# In case you want to authenticate with a System Assigned Managed Service Identity (MSI)
+kcsb = KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication(cluster)
+
+# In case you want to authenticate with a User Assigned Managed Service Identity (MSI)
+user_assigned_client_id="the AAD identity client id"
+kcsb = KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication(cluster, client_id=user_assigned_client_id)
+
 # In case you want to authenticate with AAD username and password
 username = "<username>"
 password = "<password>"

--- a/azure-kusto-data/tests/sample.py
+++ b/azure-kusto-data/tests/sample.py
@@ -37,7 +37,7 @@ kcsb = KustoConnectionStringBuilder.with_aad_application_certificate_authenticat
 kcsb = KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication(cluster)
 
 # In case you want to authenticate with a User Assigned Managed Service Identity (MSI)
-user_assigned_client_id="the AAD identity client id"
+user_assigned_client_id = "the AAD identity client id"
 kcsb = KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication(cluster, client_id=user_assigned_client_id)
 
 # In case you want to authenticate with AAD username and password

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -200,40 +200,60 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
         object_guid = "87687687"
         res_guid = "kajsdghdijewhag"
 
+        """
+        Use of object_id and msi_res_id is disabled pending support of azure-identity
+        When version 1.4.1 is released and these parameters are supported enable the functionality and tests back 
+        """
+        exception_occurred = False
+        try:
+            KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost2", object_id=object_guid, timeout=3)
+        except ValueError:
+            exception_occurred = True
+
+        assert exception_occurred is True
+
+        exception_occurred = False
+        try:
+            KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost3", msi_res_id=res_guid)
+        except ValueError:
+            exception_occurred = True
+
+        assert exception_occurred is True
+
+
+
         kcsb = [
             KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost0", timeout=1),
             KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost1", client_id=client_guid, timeout=2),
-            KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost2", object_id=object_guid, timeout=3),
-            KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost3", msi_res_id=res_guid),
+            # KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost2", object_id=object_guid, timeout=3),
+            # KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost3", msi_res_id=res_guid),
         ]
 
         assert kcsb[0].msi_authentication
-        assert kcsb[0].msi_parameters["resource"] == "localhost0"
-        assert kcsb[0].msi_parameters["timeout"] == 1
+        assert kcsb[0].msi_parameters["connection_timeout"] == 1
         assert "client_id" not in kcsb[0].msi_parameters
         assert "object_id" not in kcsb[0].msi_parameters
         assert "msi_res_id" not in kcsb[0].msi_parameters
 
         assert kcsb[1].msi_authentication
-        assert kcsb[1].msi_parameters["resource"] == "localhost1"
-        assert kcsb[1].msi_parameters["timeout"] == 2
+        assert kcsb[1].msi_parameters["connection_timeout"] == 2
         assert kcsb[1].msi_parameters["client_id"] == client_guid
         assert "object_id" not in kcsb[1].msi_parameters
         assert "msi_res_id" not in kcsb[1].msi_parameters
 
+        """
         assert kcsb[2].msi_authentication
-        assert kcsb[2].msi_parameters["resource"] == "localhost2"
-        assert kcsb[2].msi_parameters["timeout"] == 3
+        assert kcsb[2].msi_parameters["connection_timeout"] == 3
         assert "client_id" not in kcsb[2].msi_parameters
         assert kcsb[2].msi_parameters["object_id"] == object_guid
         assert "msi_res_id" not in kcsb[2].msi_parameters
 
         assert kcsb[3].msi_authentication
-        assert kcsb[3].msi_parameters["resource"] == "localhost3"
         assert "timeout" not in kcsb[3].msi_parameters
         assert "client_id" not in kcsb[3].msi_parameters
         assert "object_id" not in kcsb[3].msi_parameters
         assert kcsb[3].msi_parameters["msi_res_id"] == res_guid
+        """
 
         exception_occurred = False
         try:

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -220,8 +220,6 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
 
         assert exception_occurred is True
 
-
-
         kcsb = [
             KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost0", timeout=1),
             KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost1", client_id=client_guid, timeout=2),

--- a/azure-kusto-data/tests/test_security.py
+++ b/azure-kusto-data/tests/test_security.py
@@ -35,11 +35,15 @@ def test_msi_auth():
     object_guid = "87687687"
     res_guid = "kajsdghdijewhag"
 
+    """
+    Use of object_id and msi_res_id is disabled pending support of azure-identity
+    When version 1.4.1 is released and these parameters are supported enable the functionality and tests back 
+    """
     kcsb = [
         KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost", timeout=1),
         KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost", client_id=client_guid, timeout=1),
-        KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost", object_id=object_guid, timeout=1),
-        KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost", msi_res_id=res_guid, timeout=1),
+        # KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost", object_id=object_guid, timeout=1),
+        # KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication("localhost", msi_res_id=res_guid, timeout=1),
     ]
 
     helpers = [_AadHelper(i) for i in kcsb]

--- a/azure-kusto-ingest/tests/sample.py
+++ b/azure-kusto-ingest/tests/sample.py
@@ -37,6 +37,13 @@ with open(filename, "r") as pem_file:
 thumbprint = "certificate's thumbprint"
 kcsb = KustoConnectionStringBuilder.with_aad_application_certificate_authentication(cluster, client_id, PEM, thumbprint, authority_id)
 
+# In case you want to authenticate with a System Assigned Managed Service Identity (MSI)
+kcsb = KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication(cluster)
+
+# In case you want to authenticate with a User Assigned Managed Service Identity (MSI)
+user_assigned_client_id = "the AAD identity client id"
+kcsb = KustoConnectionStringBuilder.with_aad_managed_service_identity_authentication(cluster, client_id=user_assigned_client_id)
+
 # In case you want to authenticate with AAD username and password
 username = "<username>"
 password = "<password>"


### PR DESCRIPTION
#### Pull Request Description

**This is a breaking change**
Azure.Identity does not support object_id and msi_res_id options to obtain a user managed service identity

---

#### Future Release Comment

**Breaking Changes:**
- Authentication via Managed Service Identity uses azure.identity instead of msrestazure.
 This library caches tokens which would resolve some issues for high capacity users.
 At the moment however, it only supports obtaining user managed service identities via the client_id hint.
 Attempting to provide object_id or msi_res_id to KustoConnectionStringBuilder with throw a ValueError.