### PR TITLE
Users/yogilad/sni auth

### DIFF
--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -250,7 +250,7 @@ class KustoConnectionStringBuilder:
 
     @classmethod
     def with_aad_application_certificate_sni_authentication(
-            cls, connection_string: str, aad_app_id: str, private_certificate: str, public_certificate: str, thumbprint: str, authority_id: str
+        cls, connection_string: str, aad_app_id: str, private_certificate: str, public_certificate: str, thumbprint: str, authority_id: str
     ) -> "KustoConnectionStringBuilder":
         """
         Creates a KustoConnection string builder that will authenticate with AAD application using

--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -220,8 +220,9 @@ class _AadHelper:
             webbrowser.open(code[OAuth2DeviceCodeResponseParameters.VERIFICATION_URL])
             token = self.auth_context.acquire_token_with_device_code(self.kusto_uri, code, self.client_id)
         elif self.authentication_method in (AuthenticationMethod.aad_application_certificate, AuthenticationMethod.aad_application_certificate):
-            token = self.auth_context.acquire_token_with_client_certificate(self.kusto_uri, self.client_id, self.private_certificate, self.thumbprint,
-                                                                            self.public_certificate)
+            token = self.auth_context.acquire_token_with_client_certificate(
+                self.kusto_uri, self.client_id, self.private_certificate, self.thumbprint, self.public_certificate
+            )
         else:
             raise KustoClientError("Please choose authentication method from azure.kusto.data.security.AuthenticationMethod")
 

--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -58,6 +58,7 @@ class AuthenticationMethod(Enum):
     aad_username_password = "aad_username_password"
     aad_application_key = "aad_application_key"
     aad_application_certificate = "aad_application_certificate"
+    aad_application_certificate_sni = "aad_application_certificate_sni"
     aad_device_login = "aad_device_login"
     aad_token = "aad_token"
     aad_msi = "aad_msi"
@@ -78,7 +79,8 @@ class _AadHelper:
     client_id = None
     password = None
     thumbprint = None
-    certificate = None
+    private_certificate = None
+    public_certificate = None
     msi_params = None
     token_provider = None
 
@@ -96,10 +98,15 @@ class _AadHelper:
             self.client_id = kcsb.application_client_id
             self.client_secret = kcsb.application_key
         elif all([kcsb.application_client_id, kcsb.application_certificate, kcsb.application_certificate_thumbprint]):
-            self.authentication_method = AuthenticationMethod.aad_application_certificate
             self.client_id = kcsb.application_client_id
-            self.certificate = kcsb.application_certificate
+            self.private_certificate = kcsb.application_certificate
             self.thumbprint = kcsb.application_certificate_thumbprint
+            if all([kcsb.application_public_certificate]):
+                self.public_certificate = kcsb.application_public_certificate
+                self.authentication_method = AuthenticationMethod.aad_application_certificate_sni
+            else:
+                self.authentication_method = AuthenticationMethod.aad_application_certificate
+
         elif kcsb.msi_authentication:
             self.authentication_method = AuthenticationMethod.aad_msi
             self.msi_params = kcsb.msi_parameters
@@ -133,7 +140,7 @@ class _AadHelper:
                 kwargs = {"client_id": self.client_id}
             elif self.authentication_method is AuthenticationMethod.aad_device_login:
                 kwargs = {"client_id": self.client_id}
-            elif self.authentication_method is AuthenticationMethod.aad_application_certificate:
+            elif self.authentication_method in (AuthenticationMethod.aad_application_certificate, AuthenticationMethod.aad_application_certificate_sni):
                 kwargs = {"client_id": self.client_id, "thumbprint": self.thumbprint}
             elif self.authentication_method is AuthenticationMethod.aad_msi:
                 kwargs = self.msi_params
@@ -212,8 +219,9 @@ class _AadHelper:
             print(code[OAuth2DeviceCodeResponseParameters.MESSAGE])
             webbrowser.open(code[OAuth2DeviceCodeResponseParameters.VERIFICATION_URL])
             token = self.auth_context.acquire_token_with_device_code(self.kusto_uri, code, self.client_id)
-        elif self.authentication_method is AuthenticationMethod.aad_application_certificate:
-            token = self.auth_context.acquire_token_with_client_certificate(self.kusto_uri, self.client_id, self.certificate, self.thumbprint)
+        elif self.authentication_method in (AuthenticationMethod.aad_application_certificate, AuthenticationMethod.aad_application_certificate):
+            token = self.auth_context.acquire_token_with_client_certificate(self.kusto_uri, self.client_id, self.private_certificate, self.thumbprint,
+                                                                            self.public_certificate)
         else:
             raise KustoClientError("Please choose authentication method from azure.kusto.data.security.AuthenticationMethod")
 

--- a/azure-kusto-data/tests/sample.py
+++ b/azure-kusto-data/tests/sample.py
@@ -33,6 +33,18 @@ with open(filename, "r") as pem_file:
 thumbprint = "certificate's thumbprint"
 kcsb = KustoConnectionStringBuilder.with_aad_application_certificate_authentication(cluster, client_id, PEM, thumbprint, authority_id)
 
+# In case you want to authenticate with AAD application certificate Subject Name & Issuer
+filename = "path to a PEM certificate"
+with open(filename, "r") as pem_file:
+    PEM = pem_file.read()
+
+filename = "path to a public certificate"
+with open(filename, "r") as cert_file:
+    public_certificate = cert_file.read()
+
+thumbprint = "certificate's thumbprint"
+kcsb = KustoConnectionStringBuilder.with_aad_application_certificate_sni_authentication(cluster, client_id, PEM, public_certificate, thumbprint, authority_id)
+
 # In case you want to authenticate with AAD username and password
 username = "<username>"
 password = "<password>"

--- a/azure-kusto-ingest/tests/sample.py
+++ b/azure-kusto-ingest/tests/sample.py
@@ -37,6 +37,18 @@ with open(filename, "r") as pem_file:
 thumbprint = "certificate's thumbprint"
 kcsb = KustoConnectionStringBuilder.with_aad_application_certificate_authentication(cluster, client_id, PEM, thumbprint, authority_id)
 
+# In case you want to authenticate with AAD application certificate Subject Name & Issuer
+filename = "path to a PEM certificate"
+with open(filename, "r") as pem_file:
+    PEM = pem_file.read()
+
+filename = "path to a public certificate"
+with open(filename, "r") as cert_file:
+    public_certificate = cert_file.read()
+
+thumbprint = "certificate's thumbprint"
+kcsb = KustoConnectionStringBuilder.with_aad_application_certificate_sni_authentication(cluster, client_id, PEM, public_certificate, thumbprint, authority_id)
+
 # In case you want to authenticate with AAD username and password
 username = "<username>"
 password = "<password>"


### PR DESCRIPTION
#### Pull Request Description

Add an option to authenticate with a certificate subject name and issuer
[Reference to ADAL's auth function](https://docs.microsoft.com/en-us/python/api/adal/adal.authentication_context.authenticationcontext?view=azure-python#acquire-token-with-client-certificate-resource--client-id--certificate--thumbprint--public-certificate-none-)

---

#### Future Release Comment
**Features:**
- Added an option to authenticate with a certificate subject name and issuer.
`KustoConnectionStringBuilder.with_aad_application_certificate_sni_authentication(cluster, client_id, PEM, public_certificate, thumbprint, authority_id)`