### PR TITLE
Fix typo in backward compatability code in IngestionProperties

### DIFF
--- a/azure-kusto-ingest/azure/kusto/ingest/ingestion_properties.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/ingestion_properties.py
@@ -163,7 +163,7 @@ class IngestionProperties:
         dataFormat = kwargs.get("dataFormat", None)
         ingestionMapping = kwargs.get("ingestionMapping", None)
         ingestionMappingType = kwargs.get("ingestionMappingType", None)
-        ingestionMappingReference = kwargs.get("ingestionMappingType", None)
+        ingestionMappingReference = kwargs.get("ingestionMappingReference", None)
         additionalTags = kwargs.get("additionalTags", None)
         ingestIfNotExists = kwargs.get("ingestIfNotExists", None)
         ingestByTags = kwargs.get("ingestByTags", None)


### PR DESCRIPTION
#### Pull Request Description

Fixes a typo in the backwards compatibility section in `IngestionProperties`

`ingestionMappingReference` was incorrectly mapped to `ingestionMappingType`, causing some issues while migrating

---

#### Future Release Comment
No release comment required.

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Fixes a typo in the backwards compatibility section in `IngestionProperties`