### PR TITLE
Support independent clouds URIs

### DIFF
--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -326,7 +326,7 @@ class KustoConnectionStringBuilder:
     def with_aad_managed_service_identity_authentication(
         cls, connection_string: str, client_id: str = None, object_id: str = None, msi_res_id: str = None, timeout: int = None
     ) -> "KustoConnectionStringBuilder":
-        """"
+        """ "
         Creates a KustoConnection string builder that will authenticate with AAD application, using
         an application token obtained from a Microsoft Service Identity endpoint. An optional user
         assigned application ID can be added to the token.

--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -326,7 +326,7 @@ class KustoConnectionStringBuilder:
     def with_aad_managed_service_identity_authentication(
         cls, connection_string: str, client_id: str = None, object_id: str = None, msi_res_id: str = None, timeout: int = None
     ) -> "KustoConnectionStringBuilder":
-        """ "
+        """
         Creates a KustoConnection string builder that will authenticate with AAD application, using
         an application token obtained from a Microsoft Service Identity endpoint. An optional user
         assigned application ID can be added to the token.

--- a/azure-kusto-ingest/azure/kusto/ingest/_resource_manager.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_resource_manager.py
@@ -7,13 +7,14 @@ from typing import List
 from azure.kusto.data import KustoClient
 from azure.kusto.data._models import KustoResultTable
 
-_URI_FORMAT = re.compile("https://(\\w+).(queue|blob|table).core.windows.net/([\\w,-]+)\\?(.*)")
+_URI_FORMAT = re.compile("https://(\\w+).(queue|blob|table).(core.\\w+.net)/([\\w,-]+)\\?(.*)")
 
 
 class _ResourceUri:
-    def __init__(self, storage_account_name: str, object_type: str, object_name: str, sas: str):
+    def __init__(self, storage_account_name: str, object_type: str, endpoint_suffix: str, object_name: str, sas: str):
         self.storage_account_name = storage_account_name
         self.object_type = object_type
+        self.endpoint_suffix = endpoint_suffix
         self.object_name = object_name
         self.sas = sas
 
@@ -21,18 +22,18 @@ class _ResourceUri:
     def parse(cls, uri):
         """Parses uri into a ResourceUri object"""
         match = _URI_FORMAT.search(uri)
-        return cls(match.group(1), match.group(2), match.group(3), match.group(4))
+        return cls(match.group(1), match.group(2), match.group(3), match.group(4), match.group(5))
 
     @property
     def uri(self) -> str:
-        return "https://{0.storage_account_name}.{0.object_type}.core.windows.net/{0.object_name}".format(self)
+        return "https://{0.storage_account_name}.{0.object_type}.{0.endpoint_suffix}/{0.object_name}".format(self)
 
     @property
     def account_uri(self) -> str:
-        return "https://{0.storage_account_name}.{0.object_type}.core.windows.net/?{0.sas}".format(self)
+        return "https://{0.storage_account_name}.{0.object_type}.{0.endpoint_suffix}/?{0.sas}".format(self)
 
     def __str__(self):
-        return "https://{0.storage_account_name}.{0.object_type}.core.windows.net/{0.object_name}?{0.sas}"
+        return "https://{0.storage_account_name}.{0.object_type}.{0.endpoint_suffix}/{0.object_name}?{0.sas}"
 
 
 class _IngestClientResources:

--- a/azure-kusto-ingest/azure/kusto/ingest/_resource_manager.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_resource_manager.py
@@ -7,7 +7,7 @@ from typing import List
 from azure.kusto.data import KustoClient
 from azure.kusto.data._models import KustoResultTable
 
-_URI_FORMAT = re.compile("https://(\\w+).(queue|blob|table).(core.\\w+.net)/([\\w,-]+)\\?(.*)")
+_URI_FORMAT = re.compile("https://(\\w+).(queue|blob|table).(core.\\w+.\\w+)/([\\w,-]+)\\?(.*)")
 
 
 class _ResourceUri:

--- a/azure-kusto-ingest/azure/kusto/ingest/_status_q.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_status_q.py
@@ -18,8 +18,7 @@ class QueueDetails:
 
 
 class StatusQueue:
-    """StatusQueue is a class to simplify access to Kusto status queues (backed by azure storage queues).
-    """
+    """StatusQueue is a class to simplify access to Kusto status queues (backed by azure storage queues)."""
 
     def __init__(self, get_queues_func: Callable[[], List[_ResourceUri]], message_cls):
         self.get_queues_func = get_queues_func
@@ -32,8 +31,7 @@ class StatusQueue:
         ]
 
     def is_empty(self) -> bool:
-        """Checks if Status queue has any messages        
-        """
+        """Checks if Status queue has any messages"""
         return len(self.peek(1, raw=True)) == 0
 
     def _deserialize_message(self, m: QueueMessage):
@@ -47,7 +45,7 @@ class StatusQueue:
     def peek(self, n=1, raw=False) -> List[QueueMessage]:
         """Peek status queue
         :param int n: number of messages to return as part of peek.
-        :param bool raw: should message content be returned as is (no parsing).        
+        :param bool raw: should message content be returned as is (no parsing).
         """
 
         def _peek_specific_q(_q: QueueClient, _n: int) -> bool:

--- a/azure-kusto-ingest/tests/test_connection_string.py
+++ b/azure-kusto-ingest/tests/test_connection_string.py
@@ -11,12 +11,14 @@ class ResourceUriTests(unittest.TestCase):
         """Tests parsing blob uris."""
         storage_name = "storageaccountname"
         container_name = "containername"
+        endpoint_suffix = "core.windows.net"
         container_sas = "somesas"
 
-        uri = "https://{}.blob.core.windows.net/{}?{}".format(storage_name, container_name, container_sas)
+        uri = "https://{}.blob.{}/{}?{}".format(storage_name, endpoint_suffix, container_name, container_sas)
         connection_string = _ResourceUri.parse(uri)
         assert connection_string.storage_account_name == storage_name
         assert connection_string.object_type == "blob"
+        assert connection_string.endpoint_suffix == endpoint_suffix
         assert connection_string.sas == container_sas
         assert connection_string.object_name == container_name
 
@@ -24,11 +26,13 @@ class ResourceUriTests(unittest.TestCase):
         """Tests parsing queues uris."""
         storage_name = "storageaccountname"
         queue_name = "queuename"
+        endpoint_suffix = "core.windows.net"
         queue_sas = "somesas"
 
-        uri = "https://{}.queue.core.windows.net/{}?{}".format(storage_name, queue_name, queue_sas)
+        uri = "https://{}.queue.{}/{}?{}".format(storage_name, endpoint_suffix, queue_name, queue_sas)
         connection_string = _ResourceUri.parse(uri)
         assert connection_string.storage_account_name == storage_name
         assert connection_string.object_type == "queue"
+        assert connection_string.endpoint_suffix == endpoint_suffix
         assert connection_string.sas == queue_sas
         assert connection_string.object_name == queue_name

--- a/azure-kusto-ingest/tests/test_status_q.py
+++ b/azure-kusto-ingest/tests/test_status_q.py
@@ -92,12 +92,14 @@ class StatusQTests(unittest.TestCase):
         ) as mocked_get_failed_qs, mock.patch.object(QueueClient, "peek_messages", autospec=True, side_effect=fake_peek) as q_mock:
             fake_failed_queue = _ResourceUri(
                 "mocked_storage_account1",
+                "core.windows.net",
                 "queue",
                 "mocked_qf_name",
                 "sp=rl&st=2020-05-20T13:38:37Z&se=2020-05-21T13:38:37Z&sv=2019-10-10&sr=c&sig=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
             )
             fake_success_queue = _ResourceUri(
                 "mocked_storage_account2",
+                "core.windows.net",
                 "queue",
                 "mocked_qs_name",
                 "sp=rl&st=2020-05-20T13:38:37Z&se=2020-05-21T13:38:37Z&sv=2019-10-10&sr=c&sig=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
@@ -130,18 +132,21 @@ class StatusQTests(unittest.TestCase):
 
             fake_failed_queue1 = _ResourceUri(
                 "mocked_storage_account_f1",
+                "core.windows.net",
                 "queue",
                 "mocked_qf_1_name",
                 "sp=rl&st=2020-05-20T13:38:37Z&se=2020-05-21T13:38:37Z&sv=2019-10-10&sr=c&sig=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
             )
             fake_failed_queue2 = _ResourceUri(
                 "mocked_storage_account_f2",
+                "core.windows.net",
                 "queue",
                 "mocked_qf_2_name",
                 "sp=rl&st=2020-05-20T13:38:37Z&se=2020-05-21T13:38:37Z&sv=2019-10-10&sr=c&sig=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
             )
             fake_success_queue = _ResourceUri(
                 "mocked_storage_account2",
+                "core.windows.net",
                 "queue",
                 "mocked_qs_name",
                 "sp=rl&st=2020-05-20T13:38:37Z&se=2020-05-21T13:38:37Z&sv=2019-10-10&sr=c&sig=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
@@ -188,25 +193,31 @@ class StatusQTests(unittest.TestCase):
         with mock.patch.object(client._resource_manager, "get_successful_ingestions_queues") as mocked_get_success_qs, mock.patch.object(
             client._resource_manager, "get_failed_ingestions_queues"
         ) as mocked_get_failed_qs, mock.patch.object(
-            QueueClient, "receive_messages", autospec=True, side_effect=fake_receive,
+            QueueClient,
+            "receive_messages",
+            autospec=True,
+            side_effect=fake_receive,
         ) as q_receive_mock, mock.patch.object(
             QueueClient, "delete_message", return_value=None
         ) as q_del_mock:
 
             fake_failed_queue1 = _ResourceUri(
                 "mocked_storage_account_f1",
+                "core.windows.net",
                 "queue",
                 "mocked_qf_1_name",
                 "sp=rl&st=2020-05-20T13:38:37Z&se=2020-05-21T13:38:37Z&sv=2019-10-10&sr=c&sig=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
             )
             fake_failed_queue2 = _ResourceUri(
                 "mocked_storage_account_f2",
+                "core.windows.net",
                 "queue",
                 "mocked_qf_2_name",
                 "sp=rl&st=2020-05-20T13:38:37Z&se=2020-05-21T13:38:37Z&sv=2019-10-10&sr=c&sig=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
             )
             fake_success_queue = _ResourceUri(
                 "mocked_storage_account2",
+                "core.windows.net",
                 "queue",
                 "mocked_qs_name",
                 "sp=rl&st=2020-05-20T13:38:37Z&se=2020-05-21T13:38:37Z&sv=2019-10-10&sr=c&sig=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
@@ -251,19 +262,24 @@ class StatusQTests(unittest.TestCase):
         with mock.patch.object(client._resource_manager, "get_successful_ingestions_queues"), mock.patch.object(
             client._resource_manager, "get_failed_ingestions_queues"
         ) as mocked_get_failed_qs, mock.patch.object(
-            QueueClient, "receive_messages", autospec=True, side_effect=fake_receive,
+            QueueClient,
+            "receive_messages",
+            autospec=True,
+            side_effect=fake_receive,
         ) as q_receive_mock, mock.patch.object(
             QueueClient, "delete_message", return_value=None
         ):
 
             fake_failed_queue1 = _ResourceUri(
                 "mocked_storage_account_f1",
+                "core.windows.net",
                 "queue",
                 "mocked_qf_1_name",
                 "sp=rl&st=2020-05-20T13:38:37Z&se=2020-05-21T13:38:37Z&sv=2019-10-10&sr=c&sig=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
             )
             fake_failed_queue2 = _ResourceUri(
                 "mocked_storage_account_f2",
+                "core.windows.net",
                 "queue",
                 "mocked_qf_2_name",
                 "sp=rl&st=2020-05-20T13:38:37Z&se=2020-05-21T13:38:37Z&sv=2019-10-10&sr=c&sig=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",


### PR DESCRIPTION
#### Pull Request Description

Independent clouds has different endpoint suffix from public cloud.
Replace the hardcoded "core.windows.net" suffix with the actual URL suffix. 

#### Future Release Comment

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Support independent cloud endpoints URLs suffix.