### PR TITLE
Clean up data (drop created table) after running E2E tests

### DIFF
--- a/azure-kusto-ingest/tests/e2e.py
+++ b/azure-kusto-ingest/tests/e2e.py
@@ -142,7 +142,7 @@ def get_file_path() -> str:
 test_db = os.environ.get("TEST_DATABASE")
 
 python_version = "_".join([str(v) for v in sys.version_info[:3]])
-test_table = "python_test_{0}_{1}_{2}".format(python_version, str(int(time.time())), random.randint(1,100000))
+test_table = "python_test_{0}_{1}_{2}".format(python_version, str(int(time.time())), random.randint(1, 100000))
 client = KustoClient(engine_kcsb_from_env())
 ingest_client = KustoIngestClient(dm_kcsb_from_env())
 streaming_ingest_client = KustoStreamingIngestClient(engine_kcsb_from_env())


### PR DESCRIPTION
#### Pull Request Description

Clean up data (drop created table) after running E2E tests.

I remove a separate function that drops the table which was executed before starting the tests. Since the generated table name includes a second-based timestamp, this should only be necessary if the previous execution was *started* within 1 second of the current execution, including the time it took to create the table. As surprising as that might be (even if it failed immediately after creating the table and was then reexecuted), the function must've been added when this or some other situation that made this necessary was encountered. Adding randomness to the table's name should solve the same issue, but faster to reduce the E2E's already long runtime.

---