### PR TITLE
Fix support for unidentifiable OSes

### DIFF
--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -646,7 +646,7 @@ class KustoClient:
                 (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, INTERVAL_SECONDS),
                 (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, MAX_FAILED_KEEPALIVES),
             ]
-        if (
+        elif (
             sys.platform == "win32"
             and hasattr(socket, "SOL_SOCKET")
             and hasattr(socket, "SO_KEEPALIVE")
@@ -658,9 +658,11 @@ class KustoClient:
                 (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, MAX_IDLE_SECONDS),
                 (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, MAX_FAILED_KEEPALIVES),
             ]
-        if sys.platform == "darwin" and hasattr(socket, "SOL_SOCKET") and hasattr(socket, "SO_KEEPALIVE") and hasattr(socket, "IPPROTO_TCP"):
+        elif sys.platform == "darwin" and hasattr(socket, "SOL_SOCKET") and hasattr(socket, "SO_KEEPALIVE") and hasattr(socket, "IPPROTO_TCP"):
             TCP_KEEPALIVE = 0x10
             return [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1), (socket.IPPROTO_TCP, TCP_KEEPALIVE, INTERVAL_SECONDS)]
+        else:
+            return []
 
     def execute(self, database: str, query: str, properties: ClientRequestProperties = None) -> KustoResponseDataSet:
         """

--- a/azure-kusto-data/tests/test_kusto_client.py
+++ b/azure-kusto-data/tests/test_kusto_client.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License
+import sys
 import json
 import os
 import unittest
@@ -381,3 +382,21 @@ range x from 1 to 10 step 1"""
         response = client.execute_query("PythonTest", query)
 
         assert response is not None
+
+    @patch("requests.Session.post", side_effect=mocked_requests_post)
+    def test_unidentifiable_os(self, mock_post):
+        """Tests unidentifiable OS doesn't fail when composing its socket options"""
+        with patch.object(sys, "platform", "win3.1"):
+            client = KustoClient("https://somecluster.kusto.windows.net")
+            query = """print dynamic(123)"""
+            row = client.execute_query("PythonTest", query).primary_results[0].rows[0]
+            assert isinstance(row[0], int)
+
+    @patch("requests.Session.post", side_effect=mocked_requests_post)
+    def test_identifiable_os(self, mock_post):
+        """Tests identifiable OS doesn't fail when composing its socket options"""
+        with patch.object(sys, "platform", "win32"):
+            client = KustoClient("https://somecluster.kusto.windows.net")
+            query = """print dynamic(123)"""
+            row = client.execute_query("PythonTest", query).primary_results[0].rows[0]
+            assert isinstance(row[0], int)


### PR DESCRIPTION
#### Pull Request Description

When setting TCP Keep-Alive socket options, return empty list if we can't identify the OS.

---

#### Future Release Comment
**Fixes:**
- When setting TCP Keep-Alive socket options, return empty list if we can't identify the OS.