### PR TITLE
Fix helpers.to_pandas_timedelta returning incorrect pd.Timedelta

### DIFF
--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -11,10 +11,10 @@ def to_pandas_timedelta(raw_value) -> "pandas.Timedelta":
         # Kusto saves up to ticks, 1 tick == 100 nanoseconds
         return pd.to_timedelta(raw_value * 100, unit="ns")
     if isinstance(raw_value, str):
-        # The timespan format Kusto returns is 'd.hh.mm.ss.0000000'
-        # Pandas expects 'd days hh.mm.ss.0000000'
+        # The timespan format Kusto returns is 'd.hh:mm:ss.0000000' (or 'hh:mm:ss.0000000')
+        # Pandas expects 'd days hh:mm:ss.0000000'
         parts = raw_value.split(".")
-        if len(parts) < 2:
+        if len(parts) <= 2:
             return pd.to_timedelta(raw_value)
         else:
             formatted_value = raw_value.replace(".", " days ", 1)

--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -11,10 +11,10 @@ def to_pandas_timedelta(raw_value) -> "pandas.Timedelta":
         # Kusto saves up to ticks, 1 tick == 100 nanoseconds
         return pd.to_timedelta(raw_value * 100, unit="ns")
     if isinstance(raw_value, str):
-        # The timespan format Kusto returns is 'd.hh:mm:ss.0000000' (or 'hh:mm:ss.0000000')
-        # Pandas expects 'd days hh:mm:ss.0000000'
-        parts = raw_value.split(".")
-        if len(parts) <= 2:
+        # The timespan format Kusto returns is 'd.hh:mm:ss.ssssss' or 'hh:mm:ss.ssssss' or 'hh:mm:ss'
+        # Pandas expects 'd days hh:mm:ss.ssssss' or 'hh:mm:ss.ssssss' or 'hh:mm:ss'
+        parts = raw_value.split(":")
+        if "." not in parts[0]:
             return pd.to_timedelta(raw_value)
         else:
             formatted_value = raw_value.replace(".", " days ", 1)


### PR DESCRIPTION
... for string inputs that span less than one day

#### Pull Request Description

Fixes #305 

---

#### Future Release Comment

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Fix helpers.to_pandas_timedelta returning incorrect pd.Timedelta for string inputs that span less than one day