### PR TITLE
Fixed import on non-async machines

### DIFF
--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -7,7 +7,6 @@ from typing import Callable, Optional
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.identity import ManagedIdentityCredential
-from azure.identity.aio import ManagedIdentityCredential as AsyncManagedIdentityCredential
 from msal import ConfidentialClientApplication, PublicClientApplication
 
 from ._cloud_settings import CloudSettings
@@ -16,9 +15,15 @@ from .exceptions import KustoClientError, KustoAioSyntaxError
 try:
     from asgiref.sync import sync_to_async
 except ImportError:
-
     def sync_to_async(f):
         raise KustoAioSyntaxError()
+
+try:
+    from azure.identity.aio import ManagedIdentityCredential as AsyncManagedIdentityCredential
+except ImportError:
+    class AsyncManagedIdentityCredential:
+        def __init__(self):
+            raise KustoAioSyntaxError()
 
 
 # constant key names and values used throughout the code

--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -19,6 +19,7 @@ except ImportError:
     def sync_to_async(f):
         raise KustoAioSyntaxError()
 
+
 try:
     from azure.identity.aio import ManagedIdentityCredential as AsyncManagedIdentityCredential
 except ImportError:

--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -15,12 +15,14 @@ from .exceptions import KustoClientError, KustoAioSyntaxError
 try:
     from asgiref.sync import sync_to_async
 except ImportError:
+
     def sync_to_async(f):
         raise KustoAioSyntaxError()
 
 try:
     from azure.identity.aio import ManagedIdentityCredential as AsyncManagedIdentityCredential
 except ImportError:
+
     class AsyncManagedIdentityCredential:
         def __init__(self):
             raise KustoAioSyntaxError()


### PR DESCRIPTION
Per the email, we can't even import the async managed identity if the aiohttp package isn't installed.
This fixes that like the other method - with a shim that throws when called, which in sync code never will.