### PR TITLE
Fix ingestion endpoint format

### DIFF
--- a/azure-kusto-ingest/tests/sample.py
+++ b/azure-kusto-ingest/tests/sample.py
@@ -18,7 +18,7 @@ from azure.kusto.ingest import (
 ##################################################################
 ##                              AUTH                            ##
 ##################################################################
-cluster = "https://ingest-{cluster_name}.kusto.windows.net"
+cluster = "https://ingest-{cluster_name}.kusto.windows.net/"
 
 # In case you want to authenticate with AAD application.
 client_id = "<insert here your AAD application id>"


### PR DESCRIPTION
Without the forward slash, this error appears (where `X` would be your cluster in `https://ingest-X.kusto.windows.net/`)

```
azure.kusto.data.exceptions.KustoServiceError: [{'error': {'code': 'BadRequest', 'message': 'Request is invalid and cannot be executed.', '@type': 'Kusto.Common.Svc.Exceptions.AdminCommandWrongEndpointException', '@message': "Cannot get ingestion resources from this service endpoint. The appropriate endpoint is most likely 'https://ingest-X.kusto.windows.net/'.", '@context': {'timestamp': '2021-04-02T07:07:06.6027760Z', ...
```
After adding the forward slash as error suggests, I was able to connect to endpoint.

**Fixes:**
- Ingestion end point is accepted. 