### PR TITLE
Use Azure.Identity AzCliTokenProvider to get a token from AzCli

### DIFF
--- a/azure-kusto-data/azure/kusto/data/_cloud_settings.py
+++ b/azure-kusto-data/azure/kusto/data/_cloud_settings.py
@@ -6,7 +6,7 @@ PUBLIC_LOGIN_URL = "https://login.microsoftonline.com"
 
 
 class CloudInfo:
-    """ This class holds the data for a specific cloud instance. """
+    """This class holds the data for a specific cloud instance."""
 
     def __init__(self, auth_endpoint: str, kusto_client_app_id: str, redirect_uri: str):
         self.aad_authority_uri = auth_endpoint
@@ -15,7 +15,7 @@ class CloudInfo:
 
 
 class CloudSettings:
-    """ This class holds data for all cloud instances, and returns the specific data instance by parsing the dns suffix from a URL """
+    """This class holds data for all cloud instances, and returns the specific data instance by parsing the dns suffix from a URL"""
 
     _cloud_info = None
 
@@ -30,6 +30,6 @@ class CloudSettings:
 
     @classmethod
     def get_cloud_info(cls) -> CloudInfo:
-        """ Get the details of a cloud according to the DNS suffix of the provided connection string """
+        """Get the details of a cloud according to the DNS suffix of the provided connection string"""
         cls._init_once()
         return cls._cloud_info

--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -284,7 +284,9 @@ class AzCliTokenProvider(TokenProviderBase):
             self._az_token = self._az_auth_context.get_token(self._kusto_uri)
             return {TokenConstants.AZ_TOKEN_TYPE: TokenConstants.BEARER_TYPE, TokenConstants.AZ_ACCESS_TOKEN: self._az_token.token}
         except Exception as e:
-            raise KustoClientError("Failed to obtain Az Cli token for '{0}'\n{1}".format(self._kusto_uri, e))
+            raise KustoClientError(
+                "Failed to obtain Az Cli token for '{0}'.\nPlease be sure AzCli version 2.3.0 and above is intalled.\n{1}".format(self._kusto_uri, e)
+            )
 
     async def _get_token_impl_async(self) -> Optional[dict]:
         try:
@@ -295,7 +297,7 @@ class AzCliTokenProvider(TokenProviderBase):
             return {TokenConstants.AZ_TOKEN_TYPE: TokenConstants.BEARER_TYPE, TokenConstants.AZ_ACCESS_TOKEN: self._az_token.token}
         except Exception as e:
             raise KustoClientError(
-                "Failed to obtain Az Cli token for '{0}'.\nPlease be sure to use AzCli version 2.3.0 and above.\n{1}".format(self._kusto_uri, e)
+                "Failed to obtain Az Cli token for '{0}'.\nPlease be sure AzCli version 2.3.0 and above is installed.\n{1}".format(self._kusto_uri, e)
             )
 
     def _get_token_from_cache_impl(self) -> dict:

--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -293,7 +293,7 @@ class AzCliTokenProvider(TokenProviderBase):
             self._az_token = await self._az_auth_context_async.get_token(self._kusto_uri, self._az_kwargs)
             return {TokenConstants.AZ_TOKEN_TYPE: TokenConstants.BEARER_TYPE, TokenConstants.AZ_ACCESS_TOKEN: self._az_token.token}
         except Exception as e:
-            raise KustoClientError("Failed to obtain Az Cli token for '{0}'\n{1}".format(self._kusto_uri, e))
+            raise KustoClientError("Failed to obtain Az Cli token for '{0}'.\nPlease be sure to use AzCli version 2.3.0 and above.\n{1}".format(self._kusto_uri, e))
 
     def _get_token_from_cache_impl(self) -> dict:
         if self._az_token is not None:

--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -66,7 +66,7 @@ class TokenProviderBase(abc.ABC):
             self._cloud_info = CloudSettings.get_cloud_info()
 
     def get_token(self):
-        """ Get a token silently from cache or authenticate if cached token is not found """
+        """Get a token silently from cache or authenticate if cached token is not found"""
 
         if not self._initialized:
             with TokenProviderBase.lock:
@@ -82,7 +82,7 @@ class TokenProviderBase(abc.ABC):
         return self._valid_token_or_throw(token)
 
     async def get_token_async(self):
-        """ Get a token asynchronously silently from cache or authenticate if cached token is not found """
+        """Get a token asynchronously silently from cache or authenticate if cached token is not found"""
         with TokenProviderBase.lock:
             if not self._initialized:
                 self._init_impl()
@@ -99,35 +99,35 @@ class TokenProviderBase(abc.ABC):
     @staticmethod
     @abc.abstractmethod
     def name() -> str:
-        """ return the provider class name """
+        """return the provider class name"""
         pass
 
     @abc.abstractmethod
     def context(self) -> dict:
-        """ return a secret-free context for error reporting """
+        """return a secret-free context for error reporting"""
         pass
 
     @abc.abstractmethod
     def _init_impl(self):
-        """ Implement any "heavy" first time initializations here """
+        """Implement any "heavy" first time initializations here"""
         pass
 
     @abc.abstractmethod
     def _get_token_impl(self) -> Optional[dict]:
-        """ implement actual token acquisition here """
+        """implement actual token acquisition here"""
         pass
 
     @abc.abstractmethod
     def _get_token_from_cache_impl(self) -> Optional[dict]:
-        """ Implement cache checks here, return None if cache check fails """
+        """Implement cache checks here, return None if cache check fails"""
         pass
 
     async def _get_token_from_cache_impl_async(self) -> Optional[dict]:
-        """ Implement cache checks here, return None if cache check fails """
+        """Implement cache checks here, return None if cache check fails"""
         return await sync_to_async(self._get_token_from_cache_impl)()
 
     async def _get_token_impl_async(self) -> Optional[dict]:
-        """ implement actual token acquisition here """
+        """implement actual token acquisition here"""
         return await sync_to_async(self._get_token_impl)()
 
     @staticmethod
@@ -151,7 +151,7 @@ class TokenProviderBase(abc.ABC):
 
 
 class BasicTokenProvider(TokenProviderBase):
-    """ Basic Token Provider keeps and returns a token received on construction """
+    """Basic Token Provider keeps and returns a token received on construction"""
 
     def __init__(self, token: str):
         super().__init__(None)
@@ -175,7 +175,7 @@ class BasicTokenProvider(TokenProviderBase):
 
 
 class CallbackTokenProvider(TokenProviderBase):
-    """ Callback Token Provider generates a token based on a callback function provided by the caller """
+    """Callback Token Provider generates a token based on a callback function provided by the caller"""
 
     def __init__(self, token_callback: Callable[[], str]):
         super().__init__(None)
@@ -258,7 +258,7 @@ class MsiTokenProvider(TokenProviderBase):
 
 
 class AzCliTokenProvider(TokenProviderBase):
-    """ AzCli Token Provider obtains a refresh token from the AzCli cache and uses it to authenticate with MSAL """
+    """AzCli Token Provider obtains a refresh token from the AzCli cache and uses it to authenticate with MSAL"""
 
     def __init__(self, kusto_uri: str):
         super().__init__(kusto_uri)
@@ -312,7 +312,7 @@ class AzCliTokenProvider(TokenProviderBase):
 
 
 class UserPassTokenProvider(TokenProviderBase):
-    """ Acquire a token from MSAL with username and password """
+    """Acquire a token from MSAL with username and password"""
 
     def __init__(self, kusto_uri: str, authority_uri: str, username: str, password: str):
         super().__init__(kusto_uri)
@@ -347,7 +347,7 @@ class UserPassTokenProvider(TokenProviderBase):
 
 
 class DeviceLoginTokenProvider(TokenProviderBase):
-    """ Acquire a token from MSAL with Device Login flow """
+    """Acquire a token from MSAL with Device Login flow"""
 
     def __init__(self, kusto_uri: str, authority_uri: str, device_code_callback=None):
         super().__init__(kusto_uri)
@@ -394,7 +394,7 @@ class DeviceLoginTokenProvider(TokenProviderBase):
 
 
 class InteractiveLoginTokenProvider(TokenProviderBase):
-    """ Acquire a token from MSAL with Device Login flow """
+    """Acquire a token from MSAL with Device Login flow"""
 
     def __init__(self, kusto_uri: str, authority_uri: str, login_hint: Optional[str] = None, domain_hint: Optional[str] = None):
         super().__init__(kusto_uri)
@@ -431,7 +431,7 @@ class InteractiveLoginTokenProvider(TokenProviderBase):
 
 
 class ApplicationKeyTokenProvider(TokenProviderBase):
-    """ Acquire a token from MSAL with application Id and Key """
+    """Acquire a token from MSAL with application Id and Key"""
 
     def __init__(self, kusto_uri: str, authority_uri: str, app_client_id: str, app_key: str):
         super().__init__(kusto_uri)

--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -46,6 +46,7 @@ class TokenConstants:
     AZ_TOKEN_TYPE = "tokenType"
     AZ_ACCESS_TOKEN = "accessToken"
 
+
 class TokenProviderBase(abc.ABC):
     """
     This base class abstracts token acquisition for all implementations.
@@ -293,7 +294,9 @@ class AzCliTokenProvider(TokenProviderBase):
             self._az_token = await self._az_auth_context_async.get_token(self._kusto_uri, self._az_kwargs)
             return {TokenConstants.AZ_TOKEN_TYPE: TokenConstants.BEARER_TYPE, TokenConstants.AZ_ACCESS_TOKEN: self._az_token.token}
         except Exception as e:
-            raise KustoClientError("Failed to obtain Az Cli token for '{0}'.\nPlease be sure to use AzCli version 2.3.0 and above.\n{1}".format(self._kusto_uri, e))
+            raise KustoClientError(
+                "Failed to obtain Az Cli token for '{0}'.\nPlease be sure to use AzCli version 2.3.0 and above.\n{1}".format(self._kusto_uri, e)
+            )
 
     def _get_token_from_cache_impl(self) -> dict:
         if self._az_token is not None:
@@ -306,8 +309,6 @@ class AzCliTokenProvider(TokenProviderBase):
 
     async def _get_token_from_cache_impl_async(self) -> Optional[dict]:
         return self._get_token_from_cache_impl()
-
-
 
 
 class UserPassTokenProvider(TokenProviderBase):

--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -1,12 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License
 import abc
+import time
 import webbrowser
 from threading import Lock
 from typing import Callable, Optional
 
 from azure.core.exceptions import ClientAuthenticationError
-from azure.identity import ManagedIdentityCredential
+from azure.identity import ManagedIdentityCredential, AzureCliCredential
 from msal import ConfidentialClientApplication, PublicClientApplication
 
 from ._cloud_settings import CloudSettings
@@ -21,7 +22,7 @@ except ImportError:
 
 
 try:
-    from azure.identity.aio import ManagedIdentityCredential as AsyncManagedIdentityCredential
+    from azure.identity.aio import ManagedIdentityCredential as AsyncManagedIdentityCredential, AzureCliCredential as AsyncAzureCliCredential
 except ImportError:
 
     class AsyncManagedIdentityCredential:
@@ -44,11 +45,6 @@ class TokenConstants:
     MSAL_INTERACTIVE_PROMPT = "select_account"
     AZ_TOKEN_TYPE = "tokenType"
     AZ_ACCESS_TOKEN = "accessToken"
-    AZ_REFRESH_TOKEN = "refreshToken"
-    AZ_USER_ID = "userId"
-    AZ_AUTHORITY = "_authority"
-    AZ_CLIENT_ID = "_clientId"
-
 
 class TokenProviderBase(abc.ABC):
     """
@@ -265,10 +261,9 @@ class AzCliTokenProvider(TokenProviderBase):
 
     def __init__(self, kusto_uri: str):
         super().__init__(kusto_uri)
-        self._msal_client = None
-        self._client_id = None
-        self._authority_uri = None
-        self._username = None
+        self._az_auth_context = None
+        self._az_auth_context_async = None
+        self._az_token = None
 
     @staticmethod
     def name() -> str:
@@ -281,77 +276,38 @@ class AzCliTokenProvider(TokenProviderBase):
         pass
 
     def _get_token_impl(self) -> dict:
-        # try and obtain the refresh token from AzCli
-        refresh_token = None
-        token = None
-        stored_token = self._get_azure_cli_auth_token()
-        if TokenConstants.AZ_REFRESH_TOKEN in stored_token and TokenConstants.AZ_CLIENT_ID in stored_token and TokenConstants.AZ_AUTHORITY in stored_token:
-            refresh_token = stored_token[TokenConstants.AZ_REFRESH_TOKEN]
-            self._client_id = stored_token[TokenConstants.AZ_CLIENT_ID]
-            self._authority_uri = stored_token[TokenConstants.AZ_AUTHORITY]
-            self._username = stored_token[TokenConstants.AZ_USER_ID]
-        else:
-            raise KustoClientError("Unable to obtain a refresh token from Az-Cli. Calling 'az login' may fix this issue.")
-
-        if self._msal_client is None:
-            self._msal_client = PublicClientApplication(client_id=self._client_id, authority=self._authority_uri)
-
         try:
-            token = self._msal_client.acquire_token_by_refresh_token(refresh_token, self._scopes)
-        except Exception as ex:
-            raise KustoClientError("Unable to obtain with Az-Cli refresh token. Calling 'az login' may fix this issue.\n" + str(ex))
+            if self._az_auth_context is None:
+                self._az_auth_context = AzureCliCredential()
 
-        return self._valid_token_or_throw(token, "Calling 'az login' may fix this issue.")
+            self._az_token = self._az_auth_context.get_token(self._kusto_uri)
+            return {TokenConstants.AZ_TOKEN_TYPE: TokenConstants.BEARER_TYPE, TokenConstants.AZ_ACCESS_TOKEN: self._az_token.token}
+        except Exception as e:
+            raise KustoClientError("Failed to obtain Az Cli token for '{0}'\n{1}".format(self._kusto_uri, e))
+
+    async def _get_token_impl_async(self) -> Optional[dict]:
+        try:
+            if self._az_auth_context_async is None:
+                self._az_auth_context_async = AsyncAzureCliCredential()
+
+            self._az_token = await self._az_auth_context_async.get_token(self._kusto_uri, self._az_kwargs)
+            return {TokenConstants.AZ_TOKEN_TYPE: TokenConstants.BEARER_TYPE, TokenConstants.AZ_ACCESS_TOKEN: self._az_token.token}
+        except Exception as e:
+            raise KustoClientError("Failed to obtain Az Cli token for '{0}'\n{1}".format(self._kusto_uri, e))
 
     def _get_token_from_cache_impl(self) -> dict:
-        token = None
-        if self._msal_client is not None:
-            account = None
-            if self._username is not None:
-                accounts = self._msal_client.get_accounts(self._username)
-                if len(accounts) > 0:
-                    account = accounts[0]
+        if self._az_token is not None:
+            # A token is considered valid if it is due to expire in no less than 10 minutes
+            cur_time = time.time()
+            if (self._az_token.expires_on - 600) > cur_time:
+                return {TokenConstants.MSAL_TOKEN_TYPE: TokenConstants.BEARER_TYPE, TokenConstants.MSAL_ACCESS_TOKEN: self._az_token.token}
 
-            token = self._msal_client.acquire_token_silent(scopes=self._scopes, account=account, client_id=self._client_id, authority=self._authority_uri)
+        return None
 
-        return self._valid_token_or_none(token)
+    async def _get_token_from_cache_impl_async(self) -> Optional[dict]:
+        return self._get_token_from_cache_impl()
 
-    @staticmethod
-    def _get_azure_cli_auth_token() -> dict:
-        """
-        Try to get the az cli authenticated token
-        :return: refresh token
-        """
-        import os
 
-        try:
-            # this makes it cleaner, but in case azure cli is not present on virtual env,
-            # but cli exists on computer, we can try and manually get the token from the cache
-            from azure.cli.core._profile import Profile
-            from azure.cli.core._session import ACCOUNT
-            from azure.cli.core._environment import get_config_dir
-
-            azure_folder = get_config_dir()
-            ACCOUNT.load(os.path.join(azure_folder, "azureProfile.json"))
-            profile = Profile(storage=ACCOUNT)
-            token_data = profile.get_raw_token()[0][2]
-
-            return token_data
-
-        except ModuleNotFoundError:
-            try:
-                import os
-                import json
-
-                folder = os.getenv("AZURE_CONFIG_DIR", None) or os.path.expanduser(os.path.join("~", ".azure"))
-                token_path = os.path.join(folder, "accessTokens.json")
-                with open(token_path) as f:
-                    data = json.load(f)
-
-                # TODO: not sure I should take the first
-                return data[0]
-            except Exception as e:
-                raise KustoClientError("Azure cli token was not found. Please run 'az login' to setup account.", e)
 
 
 class UserPassTokenProvider(TokenProviderBase):

--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -501,12 +501,12 @@ class KustoConnectionStringBuilder:
 
     @property
     def msi_authentication(self):
-        """ A value stating the MSI identity type to obtain """
+        """A value stating the MSI identity type to obtain"""
         return self._internal_dict.get(self.ValidKeywords.msi_auth)
 
     @property
     def msi_parameters(self):
-        """ A user assigned MSI ID to be obtained """
+        """A user assigned MSI ID to be obtained"""
         return self._internal_dict.get(self.ValidKeywords.msi_params)
 
     @property

--- a/azure-kusto-data/tests/test_converter.py
+++ b/azure-kusto-data/tests/test_converter.py
@@ -45,9 +45,9 @@ class ConverterTests(unittest.TestCase):
         self.assertRaises(ValueError, to_timedelta, "03.00:00:00.111a")
 
     def test_to_datetime(self):
-        """ Tests datetime read by KustoResultIter """
+        """Tests datetime read by KustoResultIter"""
         assert to_datetime("2016-06-07T16:00:00Z") is not None
 
     def test_to_datetime_fail(self):
-        """ Tests that invalid strings fails to convert to datetime """
+        """Tests that invalid strings fails to convert to datetime"""
         self.assertRaises(ValueError, to_datetime, "invalid")

--- a/azure-kusto-ingest/azure/kusto/ingest/_ingestion_blob_info.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_ingestion_blob_info.py
@@ -53,15 +53,15 @@ class _IngestionBlobInfo:
             self.properties["AdditionalProperties"] = additional_properties
 
     def to_json(self):
-        """ Converts this object to a json string """
+        """Converts this object to a json string"""
         return _convert_list_to_json(self.properties)
 
 
 def _convert_list_to_json(array):
-    """ Converts array to a json string """
+    """Converts array to a json string"""
     return json.dumps(array, skipkeys=False, allow_nan=False, indent=None, separators=(",", ":"))
 
 
 def _convert_dict_to_json(array):
-    """ Converts array to a json string """
+    """Converts array to a json string"""
     return json.dumps(array, skipkeys=False, allow_nan=False, indent=None, separators=(",", ":"), sort_keys=True, default=lambda o: o.__dict__)

--- a/back_to_black.bat
+++ b/back_to_black.bat
@@ -1,0 +1,2 @@
+pip install --upgrade black
+black . --line-length 160 


### PR DESCRIPTION
#### Pull Request Description

Scrap the proprietary AzCli implementation in favor of `Azure.Identity AzCliCredential`

#### Future Release Comment
**Breaking Changes:**
- Scrap the proprietary AzCli implementation in favor of `Azure.Identity AzCliCredential`.
Note this change requires AzCli version 2.3.0 and above installed to work.