### PR TITLE
Fixed more lock errors

### DIFF
--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -218,7 +218,7 @@ class BasicTokenProvider(TokenProviderBase):
 class CallbackTokenProvider(TokenProviderBase):
     """Callback Token Provider generates a token based on a callback function provided by the caller"""
 
-    def __init__(self, token_callback: Optional[Callable[[], str]], async_token_callback: Optional[Callable[[], Coroutine[None, None, str]]] = None):
+    def __init__(self, token_callback: Optional[Callable[[], str]], async_token_callback: Optional[Callable[[], Coroutine[None, None, str]]]):
         super().__init__(None)
         self._token_callback = token_callback
         self._async_token_callback = async_token_callback

--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -242,7 +242,7 @@ class CallbackTokenProvider(TokenProviderBase):
 
     def _get_token_impl(self) -> dict:
         if self._token_callback is None:
-            raise Exception("token_callback is None, can't retrieve token")
+            raise KustoClientError("token_callback is None, can't retrieve token")
         return self._build_response(self._token_callback())
 
     async def _get_token_impl_async(self) -> Optional[dict]:

--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -5,7 +5,7 @@ import asyncio
 import time
 import webbrowser
 from threading import Lock
-from typing import Callable, Optional
+from typing import Callable, Optional, Coroutine
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.identity import ManagedIdentityCredential, AzureCliCredential
@@ -66,14 +66,14 @@ class TokenProviderBase(abc.ABC):
         # There are different locks for sync and async operations, since using a sync lock in an async context may cause a deadlock.
         # This means that theoretically, if get_token() and get_token_async() were to be called at the same time, then there might be a race condition.
         # Since this class is private, and the usage within the clients is limited to one type of function, this is ok to do.
-        self.async_lock = asyncio.Lock()
-        self.lock = Lock()
+        self._async_lock = asyncio.Lock()
+        self._lock = Lock()
 
     def _init_once(self, init_only_cloud=False):
         if self._initialized:
             return
 
-        with self.lock:
+        with self._lock:
             if self._initialized:
                 return
 
@@ -91,7 +91,7 @@ class TokenProviderBase(abc.ABC):
         if self._initialized:
             return
 
-        async with self.async_lock:
+        async with self._async_lock:
             if self._initialized:
                 return
 
@@ -120,7 +120,7 @@ class TokenProviderBase(abc.ABC):
 
         token = self._get_token_from_cache_impl()
         if token is None:
-            with self.lock:
+            with self._lock:
                 token = self._get_token_impl()
 
         return self._valid_token_or_throw(token)
@@ -136,7 +136,7 @@ class TokenProviderBase(abc.ABC):
         token = self._get_token_from_cache_impl()
 
         if token is None:
-            async with self.async_lock:
+            async with self._async_lock:
                 token = await self._get_token_impl_async()
 
         return self._valid_token_or_throw(token)
@@ -218,9 +218,10 @@ class BasicTokenProvider(TokenProviderBase):
 class CallbackTokenProvider(TokenProviderBase):
     """Callback Token Provider generates a token based on a callback function provided by the caller"""
 
-    def __init__(self, token_callback: Callable[[], str]):
+    def __init__(self, token_callback: Optional[Callable[[], str]], async_token_callback: Optional[Callable[[], Coroutine[None, None, str]]] = None):
         super().__init__(None)
         self._token_callback = token_callback
+        self._async_token_callback = async_token_callback
 
     @staticmethod
     def name() -> str:
@@ -232,12 +233,22 @@ class CallbackTokenProvider(TokenProviderBase):
     def _init_impl(self):
         pass
 
-    def _get_token_impl(self) -> dict:
-        caller_token = self._token_callback()
+    @staticmethod
+    def _build_response(caller_token) -> dict:
         if not isinstance(caller_token, str):
             raise KustoClientError("Token provider returned something that is not a string [" + str(type(caller_token)) + "]")
 
         return {TokenConstants.MSAL_TOKEN_TYPE: TokenConstants.BEARER_TYPE, TokenConstants.MSAL_ACCESS_TOKEN: caller_token}
+
+    def _get_token_impl(self) -> dict:
+        if self._token_callback is None:
+            raise Exception("token_callback is None, can't retrieve token")
+        return self._build_response(self._token_callback())
+
+    async def _get_token_impl_async(self) -> Optional[dict]:
+        if self._async_token_callback is None:
+            return await super()._get_token_impl_async()
+        return self._build_response(await self._async_token_callback())
 
     def _get_token_from_cache_impl(self) -> dict:
         return None

--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -8,7 +8,7 @@ import uuid
 from copy import copy
 from datetime import timedelta
 from enum import Enum, unique
-from typing import TYPE_CHECKING, Union, Callable, Optional, Any, NoReturn
+from typing import TYPE_CHECKING, Union, Callable, Optional, Any, NoReturn, Coroutine
 
 import requests
 from requests import Response
@@ -133,6 +133,7 @@ class KustoConnectionStringBuilder:
         _assert_value_is_valid(connection_string)
         self._internal_dict = {}
         self._token_provider = None
+        self._async_token_provider = None
         if connection_string is not None and "=" not in connection_string.partition(";")[0]:
             connection_string = "Data Source=" + connection_string
 
@@ -386,18 +387,31 @@ class KustoConnectionStringBuilder:
         return kcsb
 
     @classmethod
-    def with_token_provider(cls, connection_string: str, token_provider: Callable[[], str]) -> "KustoConnectionStringBuilder":
+    def with_token_provider(
+        cls,
+        connection_string: str,
+        token_provider: Optional[Callable[[], str]],
+        async_token_provider: Optional[Callable[[], Coroutine[None, None, str]]] = None,
+    ) -> "KustoConnectionStringBuilder":
         """
         Create a KustoConnectionStringBuilder that uses a callback function to obtain a connection token
         :param str connection_string: Kusto connection string should by of the format: https://<clusterName>.kusto.windows.net
         :param token_provider: a parameterless function that returns a valid bearer token for the relevant kusto resource as a string
+        :param async_token_provider: Optional callback that can be used with the asynchronous kusto client. If not specified, token_provider will be used.
         """
 
-        assert callable(token_provider)
+        assert (token_provider is not None) or (async_token_provider is not None), "Must specify at least one token provider"
+
+        if token_provider is not None:
+            assert callable(token_provider)
+
+        if async_token_provider is not None:
+            assert callable(async_token_provider)
 
         kcsb = cls(connection_string)
         kcsb[kcsb.ValidKeywords.aad_federated_security] = True
         kcsb._token_provider = token_provider
+        kcsb._async_token_provider = async_token_provider
 
         return kcsb
 
@@ -516,6 +530,10 @@ class KustoConnectionStringBuilder:
     @property
     def token_provider(self):
         return self._token_provider
+
+    @property
+    def async_token_provider(self):
+        return self._async_token_provider
 
     @property
     def interactive_login(self) -> bool:

--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -387,30 +387,37 @@ class KustoConnectionStringBuilder:
         return kcsb
 
     @classmethod
-    def with_token_provider(
-        cls,
-        connection_string: str,
-        token_provider: Optional[Callable[[], str]],
-        async_token_provider: Optional[Callable[[], Coroutine[None, None, str]]] = None,
-    ) -> "KustoConnectionStringBuilder":
+    def with_token_provider(cls, connection_string: str, token_provider: Callable[[], str]) -> "KustoConnectionStringBuilder":
         """
         Create a KustoConnectionStringBuilder that uses a callback function to obtain a connection token
         :param str connection_string: Kusto connection string should by of the format: https://<clusterName>.kusto.windows.net
         :param token_provider: a parameterless function that returns a valid bearer token for the relevant kusto resource as a string
-        :param async_token_provider: Optional callback that can be used with the asynchronous kusto client. If not specified, token_provider will be used.
         """
 
-        assert (token_provider is not None) or (async_token_provider is not None), "Must specify at least one token provider"
-
-        if token_provider is not None:
-            assert callable(token_provider)
-
-        if async_token_provider is not None:
-            assert callable(async_token_provider)
+        assert callable(token_provider)
 
         kcsb = cls(connection_string)
         kcsb[kcsb.ValidKeywords.aad_federated_security] = True
         kcsb._token_provider = token_provider
+
+        return kcsb
+
+    @classmethod
+    def with_async_token_provider(
+        cls,
+        connection_string: str,
+        async_token_provider: Callable[[], Coroutine[None, None, str]],
+    ) -> "KustoConnectionStringBuilder":
+        """
+        Create a KustoConnectionStringBuilder that uses an async callback function to obtain a connection token
+        :param str connection_string: Kusto connection string should by of the format: https://<clusterName>.kusto.windows.net
+        :param async_token_provider: a parameterless function that after awaiting returns a valid bearer token for the relevant kusto resource as a string
+        """
+
+        assert callable(async_token_provider)
+
+        kcsb = cls(connection_string)
+        kcsb[kcsb.ValidKeywords.aad_federated_security] = True
         kcsb._async_token_provider = async_token_provider
 
         return kcsb

--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -40,7 +40,7 @@ class _AadHelper:
         elif kcsb.az_cli:
             self.token_provider = AzCliTokenProvider(self.kusto_uri)
         elif kcsb.token_provider:
-            self.token_provider = CallbackTokenProvider(kcsb.token_provider)
+            self.token_provider = CallbackTokenProvider(kcsb.token_provider, kcsb.async_token_provider)
         else:
             self.token_provider = DeviceLoginTokenProvider(self.kusto_uri, kcsb.authority_id)
 

--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -39,8 +39,8 @@ class _AadHelper:
             self.token_provider = BasicTokenProvider(kcsb.application_token)
         elif kcsb.az_cli:
             self.token_provider = AzCliTokenProvider(self.kusto_uri)
-        elif kcsb.token_provider:
-            self.token_provider = CallbackTokenProvider(kcsb.token_provider, kcsb.async_token_provider)
+        elif kcsb.token_provider or kcsb.async_token_provider:
+            self.token_provider = CallbackTokenProvider(token_callback=kcsb.token_provider, async_token_callback=kcsb.async_token_provider)
         else:
             self.token_provider = DeviceLoginTokenProvider(self.kusto_uri, kcsb.authority_id)
 

--- a/azure-kusto-data/tests/aio/test_async_token_providers.py
+++ b/azure-kusto-data/tests/aio/test_async_token_providers.py
@@ -113,11 +113,11 @@ class TestTokenProvider:
     @aio_documented_by(TokenProviderTests.test_callback_token_provider)
     @pytest.mark.asyncio
     async def test_callback_token_provider(self):
-        provider = CallbackTokenProvider(lambda: TOKEN_VALUE)
+        provider = CallbackTokenProvider(token_callback=lambda: TOKEN_VALUE, async_token_callback=None)
         token = await provider.get_token_async()
         assert self.get_token_value(token) == TOKEN_VALUE
 
-        provider = CallbackTokenProvider(lambda: 0)  # token is not a string
+        provider = CallbackTokenProvider(token_callback=lambda: 0, async_token_callback=None)  # token is not a string
         exception_occurred = False
         try:
             await provider.get_token_async()
@@ -131,14 +131,14 @@ class TestTokenProvider:
         async def callback():
             return TOKEN_VALUE
 
-        provider = CallbackTokenProvider(None, callback)
+        provider = CallbackTokenProvider(token_callback=None, async_token_callback=callback)
         token = await provider.get_token_async()
         assert self.get_token_value(token) == TOKEN_VALUE
 
         async def fail_callback():
             return 0
 
-        provider = CallbackTokenProvider(fail_callback)  # token is not a string
+        provider = CallbackTokenProvider(token_callback=None, async_token_callback=fail_callback)  # token is not a string
         exception_occurred = False
         try:
             await provider.get_token_async()
@@ -349,7 +349,7 @@ class TestTokenProvider:
                 await asyncio.sleep(0.1)
                 return ""
 
-            provider = CallbackTokenProvider(None, inner)
+            provider = CallbackTokenProvider(token_callback=None, async_token_callback=inner)
 
             await asyncio.gather(provider.get_token_async(), provider.get_token_async(), provider.get_token_async())
 

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -264,6 +264,10 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
     def test_add_token_provider(self):
         caller_token = "caller token"
         token_provider = lambda: caller_token
+
+        async def async_token_provider():
+            return caller_token
+
         kscb = KustoConnectionStringBuilder.with_token_provider("localhost", token_provider)
 
         assert kscb.token_provider() == caller_token
@@ -271,6 +275,25 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
         exception_occurred = False
         try:
             kscb = KustoConnectionStringBuilder.with_token_provider("localhost", caller_token)
+        except AssertionError as ex:
+            exception_occurred = True
+        finally:
+            assert exception_occurred
+
+        kscb = KustoConnectionStringBuilder.with_token_provider("localhost", None, async_token_provider)
+
+        assert kscb.async_token_provider() is not None
+
+        exception_occurred = False
+        try:
+            kscb = KustoConnectionStringBuilder.with_token_provider("localhost", None, caller_token)
+        except AssertionError as ex:
+            exception_occurred = True
+        finally:
+            assert exception_occurred
+
+        try:
+            kscb = KustoConnectionStringBuilder.with_token_provider("localhost", None, None)
         except AssertionError as ex:
             exception_occurred = True
         finally:

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -265,9 +265,6 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
         caller_token = "caller token"
         token_provider = lambda: caller_token
 
-        async def async_token_provider():
-            return caller_token
-
         kscb = KustoConnectionStringBuilder.with_token_provider("localhost", token_provider)
 
         assert kscb.token_provider() == caller_token
@@ -280,20 +277,19 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
         finally:
             assert exception_occurred
 
-        kscb = KustoConnectionStringBuilder.with_token_provider("localhost", None, async_token_provider)
+    def test_add_async_token_provider(self):
+        caller_token = "caller token"
+
+        async def async_token_provider():
+            return caller_token
+
+        kscb = KustoConnectionStringBuilder.with_async_token_provider("localhost", async_token_provider)
 
         assert kscb.async_token_provider() is not None
 
         exception_occurred = False
         try:
-            kscb = KustoConnectionStringBuilder.with_token_provider("localhost", None, caller_token)
-        except AssertionError as ex:
-            exception_occurred = True
-        finally:
-            assert exception_occurred
-
-        try:
-            kscb = KustoConnectionStringBuilder.with_token_provider("localhost", None, None)
+            kscb = KustoConnectionStringBuilder.with_async_token_provider("localhost", caller_token)
         except AssertionError as ex:
             exception_occurred = True
         finally:

--- a/azure-kusto-data/tests/test_token_providers.py
+++ b/azure-kusto-data/tests/test_token_providers.py
@@ -112,11 +112,11 @@ class TokenProviderTests(unittest.TestCase):
 
     @staticmethod
     def test_callback_token_provider():
-        provider = CallbackTokenProvider(lambda: TOKEN_VALUE)
+        provider = CallbackTokenProvider(token_callback=lambda: TOKEN_VALUE, async_token_callback=None)
         token = provider.get_token()
         assert TokenProviderTests.get_token_value(token) == TOKEN_VALUE
 
-        provider = CallbackTokenProvider(lambda: 0)  # token is not a string
+        provider = CallbackTokenProvider(token_callback=lambda: 0, async_token_callback=None)  # token is not a string
         exception_occurred = False
         try:
             provider.get_token()


### PR DESCRIPTION
This version moves the locks in token_providers to individual instances, rather than per class.

Since we don't use any shared class variables (as far as I can tell), this is safe to do and beneficial for performance.

For the async lock, this is essential - since the lock must be created with the same loop as the class, this means we can't initiate it until the class is created, and it requires different locks for instances inside different loops.

