### PR TITLE
E2E - Only clear cache once

### DIFF
--- a/azure-kusto-ingest/tests/e2e.py
+++ b/azure-kusto-ingest/tests/e2e.py
@@ -38,8 +38,6 @@ from azure.kusto.ingest import (
     ManagedStreamingIngestClient,
 )
 
-CLEAR_DB_CACHE = ".clear database cache streamingingestion schema"
-
 
 @pytest.fixture(params=["ManagedStreaming", "NormalClient"])
 def is_managed_streaming(request):
@@ -207,6 +205,8 @@ class TestE2E:
 
         cls.client.execute(cls.test_db, f".alter table {cls.test_table} policy streamingingestion enable ")
 
+        cls.client.execute(cls.test_db, ".clear database cache streamingingestion schema")
+
     @classmethod
     def teardown_class(cls):
         cls.client.execute(cls.test_db, ".drop table {} ifexists".format(cls.test_table))
@@ -359,8 +359,6 @@ class TestE2E:
         )
 
         client = self.streaming_ingest_client if is_managed_streaming else self.ingest_client
-        if is_managed_streaming:
-            self.client.execute(self.test_db, CLEAR_DB_CACHE)
 
         for f in [self.csv_file_path, self.zipped_csv_file_path]:
             client.ingest_from_file(f, csv_ingest_props)
@@ -434,8 +432,6 @@ class TestE2E:
         zipped = io.BytesIO(pathlib.Path(self.zipped_json_file_path).read_bytes())
 
         client = self.managed_streaming_ingest_client if is_managed_streaming else self.ingest_client
-        if is_managed_streaming:
-            self.client.execute(self.test_db, CLEAR_DB_CACHE)
 
         client.ingest_from_stream(text, json_ingestion_props)
         client.ingest_from_stream(StreamDescriptor(zipped, is_compressed=True), json_ingestion_props)
@@ -501,7 +497,6 @@ class TestE2E:
 
     @pytest.mark.asyncio
     async def test_streaming_ingest_from_opened_file(self, is_managed_streaming):
-        self.client.execute(self.test_db, CLEAR_DB_CACHE)
         ingestion_properties = IngestionProperties(database=self.test_db, table=self.test_table, data_format=DataFormat.CSV)
 
         client = self.managed_streaming_ingest_client if is_managed_streaming else self.streaming_ingest_client
@@ -512,7 +507,6 @@ class TestE2E:
 
     @pytest.mark.asyncio
     async def test_streaming_ingest_from_csv_file(self):
-        self.client.execute(self.test_db, CLEAR_DB_CACHE)
         ingestion_properties = IngestionProperties(database=self.test_db, table=self.test_table, flush_immediately=True, data_format=DataFormat.CSV)
 
         for f in [self.csv_file_path, self.zipped_csv_file_path]:
@@ -522,7 +516,6 @@ class TestE2E:
 
     @pytest.mark.asyncio
     async def test_streaming_ingest_from_json_file(self):
-        self.client.execute(self.test_db, CLEAR_DB_CACHE)
         ingestion_properties = IngestionProperties(
             database=self.test_db,
             table=self.test_table,
@@ -539,7 +532,6 @@ class TestE2E:
 
     @pytest.mark.asyncio
     async def test_streaming_ingest_from_csv_io_streams(self):
-        self.client.execute(self.test_db, CLEAR_DB_CACHE)
         ingestion_properties = IngestionProperties(database=self.test_db, table=self.test_table, data_format=DataFormat.CSV)
         byte_sequence = b'0,00000000-0000-0000-0001-020304050607,0,0,0,0,0,0,0,0,0,0,2014-01-01T01:01:01.0000000Z,Zero,"Zero",0,00:00:00,,null'
         bytes_stream = io.BytesIO(byte_sequence)

--- a/azure-kusto-ingest/tests/e2e.py
+++ b/azure-kusto-ingest/tests/e2e.py
@@ -205,6 +205,8 @@ class TestE2E:
 
         cls.client.execute(cls.test_db, f".alter table {cls.test_table} policy streamingingestion enable ")
 
+        # Clear the cache to guarantee that subsequent streaming ingestion requests incorporate database and table schema changes
+        # See https://docs.microsoft.com/azure/data-explorer/kusto/management/data-ingestion/clear-schema-cache-command
         cls.client.execute(cls.test_db, ".clear database cache streamingingestion schema")
 
     @classmethod


### PR DESCRIPTION
We only need to clear the cache after we create the table.
This PR removes superfluous calls.