### PR TITLE
Fix Quickstart to handle both strings and bools in configs

### DIFF
--- a/quick_start/kusto_sample_app.py
+++ b/quick_start/kusto_sample_app.py
@@ -83,7 +83,7 @@ class KustoSampleApp:
                 # Tip: This is generally a one-time configuration.
                 # Learn More: For more information about providing inline mappings and mapping references, see: https://docs.microsoft.com/azure/data-explorer/kusto/management/mappings
                 if not cls.create_ingestion_mappings(
-                    strtobool(file["useExistingMapping"].lower()),
+                    strtobool(str(file["useExistingMapping"]).lower()),
                     kusto_client,
                     cls.database_name,
                     cls.table_name,
@@ -126,16 +126,16 @@ class KustoSampleApp:
         except Exception as ex:
             cls.die(f"Couldn't read load config file from file '{config_file_name}'", ex)
 
-        cls.use_existing_table = strtobool(config["useExistingTable"].lower())
+        cls.use_existing_table = strtobool(str(config["useExistingTable"]).lower())
         cls.database_name = config["databaseName"]
         cls.table_name = config["tableName"]
         cls.table_schema = config["tableSchema"]
         cls.kusto_url = config["kustoUri"]
         cls.ingest_url = config["ingestUri"]
         cls.data_to_ingest = config["data"]
-        cls.should_alter_table = strtobool(config["alterTable"].lower())
-        cls.should_query_data = strtobool(config["queryData"].lower())
-        cls.should_ingest_data = strtobool(config["ingestData"].lower())
+        cls.should_alter_table = strtobool(str(config["alterTable"]).lower())
+        cls.should_query_data = strtobool(str(config["queryData"]).lower())
+        cls.should_ingest_data = strtobool(str(config["ingestData"]).lower())
         if (
             cls.database_name is None
             or cls.table_name is None


### PR DESCRIPTION
#### Pull Request Description

The config file in each SDK includes bools in their string representation. We just learned that the UI is planning on sending these values as bools. We therefore want to be resilient to handle both.

---

#### Future Release Comment
The config file in each SDK includes bools in their string representation. But the UI is planning on sending these values as bools. We therefore want to be resilient to handle both.

**Fixes:**
- Fix Quickstart to handle both strings and bools in configs