### PR TITLE
Save space by using numpy datatype "int32" instead of "int64" for ADX int

### DIFF
--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -53,12 +53,12 @@ def dataframe_from_result_table(table: "Union[KustoResultTable, KustoStreamingRe
         if col.column_type == "bool":
             frame[col.column_name] = frame[col.column_name].astype(bool)
         elif col.column_type == "int":
-            frame[col.column_name] = frame[col.column_name].astype("int32")
+            frame[col.column_name] = frame[col.column_name].astype("Int32")
         elif col.column_type == "long":
-            frame[col.column_name] = frame[col.column_name].astype("int64")
+            frame[col.column_name] = frame[col.column_name].astype("Int64")
         elif col.column_type == "real" or col.column_type == "decimal":
             frame[col.column_name] = frame[col.column_name].replace("NaN", np.NaN).replace("Infinity", np.PINF).replace("-Infinity", np.NINF)
-            frame[col.column_name] = pd.to_numeric(frame[col.column_name], errors="coerce").astype("float64")
+            frame[col.column_name] = pd.to_numeric(frame[col.column_name], errors="coerce").astype("Float64")
         elif col.column_type == "datetime":
             frame[col.column_name] = pd.to_datetime(frame[col.column_name], errors="coerce")
         elif col.column_type == "timespan":

--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -52,11 +52,13 @@ def dataframe_from_result_table(table: "Union[KustoResultTable, KustoStreamingRe
     for col in table.columns:
         if col.column_type == "bool":
             frame[col.column_name] = frame[col.column_name].astype(bool)
-        elif col.column_type == "int" or col.column_type == "long":
-            frame[col.column_name] = frame[col.column_name].astype("Int64")
+        elif col.column_type == "int":
+            frame[col.column_name] = frame[col.column_name].astype("int32")
+        elif col.column_type == "long":
+            frame[col.column_name] = frame[col.column_name].astype("int64")
         elif col.column_type == "real" or col.column_type == "decimal":
             frame[col.column_name] = frame[col.column_name].replace("NaN", np.NaN).replace("Infinity", np.PINF).replace("-Infinity", np.NINF)
-            frame[col.column_name] = pd.to_numeric(frame[col.column_name], errors="coerce").astype("Float64")
+            frame[col.column_name] = pd.to_numeric(frame[col.column_name], errors="coerce").astype("float64")
         elif col.column_type == "datetime":
             frame[col.column_name] = pd.to_datetime(frame[col.column_name], errors="coerce")
         elif col.column_type == "timespan":

--- a/azure-kusto-data/tests/kusto_client_common.py
+++ b/azure-kusto-data/tests/kusto_client_common.py
@@ -314,7 +314,7 @@ class KustoClientTestsMixin:
 
         assert len(data_frame.columns) == 19
         expected_dict = {
-            "rownumber": Series([None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype="Int64"),
+            "rownumber": Series([None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype="Int32"),
             "rowguid": Series(
                 [
                     "",
@@ -334,8 +334,8 @@ class KustoClientTestsMixin:
             "xdouble": Series([None, 0.0, 1.0001, 2.0002, 3.0003, 4.0004, 5.0005, 6.0006, 7.0007, 8.0008, 9.0009], dtype="Float64"),
             "xfloat": Series([None, 0.0, 1.01, 2.02, 3.03, 4.04, 5.05, 6.06, 7.07, 8.08, 9.09], dtype="Float64"),
             "xbool": Series([None, False, True, False, True, False, True, False, True, False, True], dtype=bool),
-            "xint16": Series([None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype="Int64"),
-            "xint32": Series([None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype="Int64"),
+            "xint16": Series([None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype="Int32"),
+            "xint32": Series([None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype="Int32"),
             "xint64": Series([None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype="Int64"),
             "xuint8": Series([None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype="Int64"),
             "xuint16": Series([None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype="Int64"),

--- a/azure-kusto-data/tests/test_helpers.py
+++ b/azure-kusto-data/tests/test_helpers.py
@@ -37,7 +37,7 @@ class TestDataFrameFromResultsTable:
         assert all(getattr(df.iloc[0].RecordTime, k) == v for k, v in {"year": 2021, "month": 12, "day": 22, "hour": 11, "minute": 43, "second": 00}.items())
         assert type(df.iloc[0].RecordBool) is numpy.bool_
         assert df.iloc[0].RecordBool == True
-        assert type(df.iloc[0].RecordInt) is numpy.int64
+        assert type(df.iloc[0].RecordInt) is numpy.int32
         assert df.iloc[0].RecordInt == 5678
         assert type(df.iloc[0].RecordReal) is numpy.float64
         assert df.iloc[0].RecordReal == 3.14159


### PR DESCRIPTION
#### Pull Request Description

Save space by using numpy datatype "int32" instead of "int64" for ADX datatype of "int" (which is a 32-bit integer).

---

#### Future Release Comment
**Fixes:**
- Save space by using numpy datatype "int32" instead of "int64" for ADX datatype of "int" (which is a 32-bit integer).