### PR TITLE
Replace reference to Java environment setup guide with Python

### DIFF
--- a/quick_start/README.md
+++ b/quick_start/README.md
@@ -10,8 +10,7 @@ You can use it as a baseline to write your own first kusto client application, a
 
 ### Prerequisites
 
-1. Set up Python version 3.7 or higher on your machine. For instructions, consult a Python environment setup tutorial, like [this](https://www.
-   tutorialspoint.com/java/java_environment_setup.htm).
+1. Set up Python version 3.7 or higher on your machine. For instructions, consult a Python environment setup tutorial, like [this](https://www.tutorialspoint.com/python/python_environment.htm).
 
 ### Retrieving the app from GitHub
 

--- a/quick_start/oneclick_instruction_box.md
+++ b/quick_start/oneclick_instruction_box.md
@@ -1,7 +1,6 @@
 ### Prerequisites
 
-1. Set up Python version 3.7 or higher on your machine. For instructions, consult a Python environment setup tutorial, like [this](https://www.
-   tutorialspoint.com/java/java_environment_setup.htm).
+1. Set up Python version 3.7 or higher on your machine. For instructions, consult a Python environment setup tutorial, like [this](https://www.tutorialspoint.com/python/python_environment.htm).
 
 ### Instructions
 


### PR DESCRIPTION
#### Pull Request Description

Replace reference to Java environment setup guide with Python

---

#### Future Release Comment

**Breaking Changes:**
**Fixes:**
- Replace reference to Java environment setup guide with Python