### PR TITLE
Add proxy support to ingest

### DIFF
--- a/azure-kusto-ingest/azure/kusto/ingest/_resource_manager.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/_resource_manager.py
@@ -140,3 +140,6 @@ class _ResourceManager:
             return command_result.primary_results[0][0][_SERVICE_TYPE_COLUMN_NAME]
         except (TypeError, KeyError):
             return ""
+
+    def set_proxy(self, proxy_url: str):
+        self._kusto_client.set_proxy(proxy_url)

--- a/azure-kusto-ingest/azure/kusto/ingest/base_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/base_ingest_client.py
@@ -78,6 +78,13 @@ class BaseIngestClient(metaclass=ABCMeta):
         """
         pass
 
+    @abstractmethod
+    def set_proxy(self, proxy_url: str):
+        """Set proxy for the ingestion client.
+        :param str proxy_url: proxy url.
+        """
+        pass
+
     def ingest_from_dataframe(self, df: "pandas.DataFrame", ingestion_properties: IngestionProperties) -> IngestionResult:
         """Enqueue an ingest command from local files.
         To learn more about ingestion methods go to:

--- a/azure-kusto-ingest/azure/kusto/ingest/managed_streaming_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/managed_streaming_ingest_client.py
@@ -63,6 +63,10 @@ class ManagedStreamingIngestClient(BaseIngestClient):
         self.queued_client = QueuedIngestClient(dm_kcsb)
         self.streaming_client = KustoStreamingIngestClient(engine_kcsb)
 
+    def set_proxy(self, proxy_url: str):
+        self.queued_client.set_proxy(proxy_url)
+        self.streaming_client.set_proxy(proxy_url)
+
     def ingest_from_file(self, file_descriptor: Union[FileDescriptor, str], ingestion_properties: IngestionProperties) -> IngestionResult:
         stream_descriptor = StreamDescriptor.from_file_descriptor(file_descriptor)
 

--- a/azure-kusto-ingest/azure/kusto/ingest/streaming_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/streaming_ingest_client.py
@@ -23,6 +23,9 @@ class KustoStreamingIngestClient(BaseIngestClient):
         """
         self._kusto_client = KustoClient(kcsb)
 
+    def set_proxy(self, proxy_url: str):
+        self._kusto_client.set_proxy(proxy_url)
+
     def ingest_from_file(self, file_descriptor: Union[FileDescriptor, str], ingestion_properties: IngestionProperties) -> IngestionResult:
         """Ingest from local files.
         :param file_descriptor: a FileDescriptor to be ingested.


### PR DESCRIPTION
Adds a "set_proxy" method for all ingest clients.
Also fixes the names of some tests.

Tested manually since automatic tests of this would be very taxing.

solves #378 