### PR TITLE
Limit service client operations to 10 minutes

### DIFF
--- a/azure-kusto-ingest/tests/test_managed_streaming_ingest.py
+++ b/azure-kusto-ingest/tests/test_managed_streaming_ingest.py
@@ -109,7 +109,8 @@ class TestManagedStreamingIngestClient:
 
         initial_bytes = bytearray(os.urandom(5 * 1024 * 1024))
 
-        def check_bytes(data):
+        def check_bytes(data, **kwargs):
+            assert kwargs["timeout"] == 10 * 60
             assert data.read() == initial_bytes
 
         mock_upload_blob_from_stream.side_effect = check_bytes
@@ -158,7 +159,8 @@ class TestManagedStreamingIngestClient:
         initial_bytes = bytearray(os.urandom(5 * 1024 * 1024))
         stream = io.BytesIO(initial_bytes)
 
-        def check_bytes(data):
+        def check_bytes(data, **kwargs):
+            assert kwargs["timeout"] == 10 * 60
             assert data.read() == initial_bytes
 
         mock_upload_blob_from_stream.side_effect = check_bytes


### PR DESCRIPTION
#### Pull Request Description

Limit service client operations to 10 minutes, as we do in the .net client.
This should solve cases where the upload hangs forever.
For now, we will not make it user-configurable.

---

#### Future Release Comment
_[Add description of your change, to include in the next release]_
_[Delete any or all irrelevant sections, e.g. if your change does not warrant a release comment at all]_

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Fixes #383 