### PR TITLE
Option 2 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ To install via the Python Package Index (PyPI), type:
 To get the source code of the SDK via git just type:
 
 ```python
-git clone git://github.com/Azure/azure-kusto-python.git
+git clone https://github.com/Azure/azure-kusto-python
 cd ./azure-kusto-python/azure-kusto-data
-python setup.py install
+python3 setup.py install
 cd ../azure-kusto-ingest
-python setup.py install
+python3 setup.py install
 ```
 
 ### Option 3: Source Zip


### PR DESCRIPTION
#### Pull Request Description

Updated install instructions

#### Future Release Comment
1. The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

2. python setup.py install resulted in an error that setuptools was not installed and pip install setuptools did not fix this. Only by using python3 setup.py install was I able to install the packages.

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Updated installation instructions