### PR TITLE
Allow passing service url with port

### DIFF
--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -32,8 +32,7 @@ class _AadHelper:
         self.kusto_uri = f"{parsed_url.scheme}://{parsed_url.hostname}"
         if parsed_url.port is not None:
             self.kusto_uri += f":{parsed_url.port}"
-        
-        
+
         self.username = None
 
         if kcsb.interactive_login:

--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -28,7 +28,12 @@ class _AadHelper:
     token_provider = None  # type: TokenProviderBase
 
     def __init__(self, kcsb: "KustoConnectionStringBuilder", is_async: bool):
-        self.kusto_uri = "{0.scheme}://{0.hostname}".format(urlparse(kcsb.data_source))
+        parsed_url = urlparse(kcsb.data_source)
+        self.kusto_uri = f"{parsed_url.scheme}://{parsed_url.hostname}"
+        if (parsed_url.port is not None) {
+            self.kusto_uri += f":{parsed_url.port}"
+        }
+        
         self.username = None
 
         if kcsb.interactive_login:

--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -30,9 +30,9 @@ class _AadHelper:
     def __init__(self, kcsb: "KustoConnectionStringBuilder", is_async: bool):
         parsed_url = urlparse(kcsb.data_source)
         self.kusto_uri = f"{parsed_url.scheme}://{parsed_url.hostname}"
-        if (parsed_url.port is not None) {
+        if parsed_url.port is not None:
             self.kusto_uri += f":{parsed_url.port}"
-        }
+        
         
         self.username = None
 


### PR DESCRIPTION
#### Pull Request Description

Adding port to aad helper (`_AadHelper`) to allow our security module to talk to services exposing a different secure port.

---

#### Future Release Comment
_[Add description of your change, to include in the next release]_
_[Delete any or all irrelevant sections, e.g. if your change does not warrant a release comment at all]_

**Breaking Changes:**
- None

**Features:**
- It is now possible to use service with non-standard https ports (explicitly provided as part of the connection string)

**Fixes:**
- None