### PR TITLE
Make numpy dependency optional

### DIFF
--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -1,7 +1,5 @@
 from typing import TYPE_CHECKING, Union
 
-import numpy as np
-
 if TYPE_CHECKING:
     import pandas
     from azure.kusto.data._models import KustoResultTable, KustoStreamingResultTable
@@ -35,6 +33,7 @@ def dataframe_from_result_table(table: "Union[KustoResultTable, KustoStreamingRe
     :param azure.kusto.data._models.KustoResultTable table: Table received from the response.
     :return: pandas DataFrame.
     """
+    import numpy as np
     import pandas as pd
 
     if not table:


### PR DESCRIPTION
#### Pull Request Description

Problem: Last version of `azure-kust-data` package (3.1.3) doesn't work without `numpy` module being present.
The error is:

```
  File "venv/lib/python3.8/site-packages/azure/kusto/data/helpers.py", line 3, in <module>
    import numpy as np
ModuleNotFoundError: No module named 'numpy'
```

The PR makes the dependency optional.

---

#### Future Release Comment
 - None

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- None