### PR TITLE
Pass settings to http parent

### DIFF
--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -17,14 +17,14 @@ from .response import KustoStreamingResponseDataSet, KustoResponseDataSet
 from .streaming_response import StreamingDataSetEnumerator, JsonTokenReader
 
 if TYPE_CHECKING:
-    pass
+    import requests.adapters
 
 
 class HTTPAdapterWithSocketOptions(requests.adapters.HTTPAdapter):
     def __init__(self, *args, **kwargs):
         self.socket_options = kwargs.pop("socket_options", None)
-        self.pool_maxsize = kwargs.pop("pool_maxsize", None)
-        self.max_retries = kwargs.pop("max_retries", None)
+        self.pool_maxsize = kwargs.get("pool_maxsize", None)
+        self.max_retries = kwargs.get("max_retries", None)
         super(HTTPAdapterWithSocketOptions, self).__init__(*args, **kwargs)
 
     def init_poolmanager(self, *args, **kwargs):


### PR DESCRIPTION
We popped the settings, so they were never passed to the parent. This PR fixes it.