### PR TITLE
Use bytes instead of string in tests

### DIFF
--- a/azure-kusto-data/tests/kusto_client_common.py
+++ b/azure-kusto-data/tests/kusto_client_common.py
@@ -4,7 +4,7 @@ import json
 import os
 import uuid
 from datetime import datetime, timedelta
-from io import StringIO
+from io import BytesIO
 from typing import Optional, Any, Dict, Union, Iterator, Tuple
 
 import pytest
@@ -27,9 +27,9 @@ except:
 def mocked_requests_post(*args, **kwargs):
     """Mock to replace requests.Session.post"""
 
-    class Raw(StringIO):
-        def __init__(self, initial_value: Optional[str]) -> None:
-            super().__init__(initial_value, None)
+    class Raw(BytesIO):
+        def __init__(self, initial_value: Optional[bytes]) -> None:
+            super().__init__(initial_value)
             self.decode_content = False
 
     class MockResponse:
@@ -42,7 +42,7 @@ def mocked_requests_post(*args, **kwargs):
             self.headers = None
             self.reason = ""
             self.url = url
-            self.raw = Raw(json.dumps(json_data))
+            self.raw = Raw(json.dumps(json_data).encode("utf-8"))
 
         def json(self) -> Optional[Dict[str, Any]]:
             """Get json data from response."""

--- a/azure-kusto-data/tests/kusto_client_common.py
+++ b/azure-kusto-data/tests/kusto_client_common.py
@@ -42,7 +42,7 @@ def mocked_requests_post(*args, **kwargs):
             self.headers = None
             self.reason = ""
             self.url = url
-            self.raw = Raw(json.dumps(json_data).encode("utf-8"))
+            self.raw = Raw(json.dumps(json_data).encode())
 
         def json(self) -> Optional[Dict[str, Any]]:
             """Get json data from response."""

--- a/azure-kusto-data/tests/test_streaming_query.py
+++ b/azure-kusto-data/tests/test_streaming_query.py
@@ -1,5 +1,5 @@
 import os
-from io import StringIO
+from io import BytesIO
 
 import pytest
 
@@ -27,12 +27,12 @@ class MockAioFile:
         return self.file.read(n)
 
 
-class AsyncStringIO:
+class AsyncBytesIO:
     def __init__(self, string):
-        self.string_io = StringIO(string)
+        self.bytes_io = BytesIO(string)
 
     async def read(self, n=-1):
-        return self.string_io.read(n)
+        return self.bytes_io.read(n)
 
 
 class TestStreamingQuery(KustoClientTestsMixin):
@@ -213,10 +213,10 @@ class TestStreamingQuery(KustoClientTestsMixin):
 
 class TestJsonTokenReader:
     def get_reader(self, data) -> JsonTokenReader:
-        return JsonTokenReader(StringIO(data))
+        return JsonTokenReader(BytesIO(data.encode("utf-8")))
 
     def get_async_reader(self, data) -> AsyncJsonTokenReader:
-        return AsyncJsonTokenReader(AsyncStringIO(data))
+        return AsyncJsonTokenReader(AsyncBytesIO(data.encode("utf-8")))
 
     def test_reading_token(self):
         reader = self.get_reader("{")

--- a/azure-kusto-data/tests/test_streaming_query.py
+++ b/azure-kusto-data/tests/test_streaming_query.py
@@ -213,10 +213,10 @@ class TestStreamingQuery(KustoClientTestsMixin):
 
 class TestJsonTokenReader:
     def get_reader(self, data) -> JsonTokenReader:
-        return JsonTokenReader(BytesIO(data.encode("utf-8")))
+        return JsonTokenReader(BytesIO(data.encode()))
 
     def get_async_reader(self, data) -> AsyncJsonTokenReader:
-        return AsyncJsonTokenReader(AsyncBytesIO(data.encode("utf-8")))
+        return AsyncJsonTokenReader(AsyncBytesIO(data.encode()))
 
     def test_reading_token(self):
         reader = self.get_reader("{")


### PR DESCRIPTION
Use bytes instead of strings in tests:
1. More correct - that's how we get the data
2. Solves warnings