### PR TITLE
Default DB + parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 ### Added
+- Added Initial Catalog (Default Database) parameter to ConnectionStringBuilder
 - Added callback parameter to device code
+- Added method to manually set the cache for CloudSettings
+### Changed
+- Urls with one item after the path (i.e https://test.com/abc) will now be treated as cluster and initial catalog (ie. the cluster is "https://test.com" and the initial catalog is "abc").
+    * This is to align our behaviour with the .NET SDK
+### Fixed
+- Some edge cases in url parsing
 
 ## [4.1.4] - 2023-04-16
 ### Fixed

--- a/azure-kusto-data/azure/kusto/data/aio/client.py
+++ b/azure-kusto-data/azure/kusto/data/aio/client.py
@@ -43,7 +43,7 @@ class KustoClient(_KustoClientBase):
         await self.close()
 
     @aio_documented_by(KustoClientSync.execute)
-    async def execute(self, database: str, query: str, properties: ClientRequestProperties = None) -> KustoResponseDataSet:
+    async def execute(self, database: Optional[str], query: str, properties: ClientRequestProperties = None) -> KustoResponseDataSet:
         query = query.strip()
         if query.startswith("."):
             return await self.execute_mgmt(database, query, properties)
@@ -51,14 +51,16 @@ class KustoClient(_KustoClientBase):
 
     @distributed_trace_async(name_of_span="KustoClient.query_cmd", kind=SpanKind.CLIENT)
     @aio_documented_by(KustoClientSync.execute_query)
-    async def execute_query(self, database: str, query: str, properties: ClientRequestProperties = None) -> KustoResponseDataSet:
+    async def execute_query(self, database: Optional[str], query: str, properties: ClientRequestProperties = None) -> KustoResponseDataSet:
+        database = self.get_database(database)
         KustoTracingAttributes.set_query_attributes(self._kusto_cluster, database, properties)
 
         return await self._execute(self._query_endpoint, database, query, None, KustoClient._query_default_timeout, properties)
 
     @distributed_trace_async(name_of_span="KustoClient.control_cmd", kind=SpanKind.CLIENT)
     @aio_documented_by(KustoClientSync.execute_mgmt)
-    async def execute_mgmt(self, database: str, query: str, properties: ClientRequestProperties = None) -> KustoResponseDataSet:
+    async def execute_mgmt(self, database: Optional[str], query: str, properties: ClientRequestProperties = None) -> KustoResponseDataSet:
+        database = self.get_database(database)
         KustoTracingAttributes.set_query_attributes(self._kusto_cluster, database, properties)
 
         return await self._execute(self._mgmt_endpoint, database, query, None, KustoClient._mgmt_default_timeout, properties)
@@ -67,13 +69,14 @@ class KustoClient(_KustoClientBase):
     @aio_documented_by(KustoClientSync.execute_streaming_ingest)
     async def execute_streaming_ingest(
         self,
-        database: str,
+        database: Optional[str],
         table: str,
         stream: io.IOBase,
         stream_format: Union[DataFormat, str],
         properties: ClientRequestProperties = None,
         mapping_name: str = None,
     ):
+        database = self.get_database(database)
         KustoTracingAttributes.set_streaming_ingest_attributes(self._kusto_cluster, database, table, properties)
 
         stream_format = stream_format.kusto_value if isinstance(stream_format, DataFormat) else DataFormat[stream_format.upper()].kusto_value
@@ -85,7 +88,11 @@ class KustoClient(_KustoClientBase):
 
     @aio_documented_by(KustoClientSync._execute_streaming_query_parsed)
     async def _execute_streaming_query_parsed(
-        self, database: str, query: str, timeout: timedelta = _KustoClientBase._query_default_timeout, properties: Optional[ClientRequestProperties] = None
+        self,
+        database: Optional[str],
+        query: str,
+        timeout: timedelta = _KustoClientBase._query_default_timeout,
+        properties: Optional[ClientRequestProperties] = None,
     ) -> StreamingDataSetEnumerator:
         response = await self._execute(self._query_endpoint, database, query, None, timeout, properties, stream_response=True)
         return StreamingDataSetEnumerator(JsonTokenReader(response.content))
@@ -93,8 +100,13 @@ class KustoClient(_KustoClientBase):
     @distributed_trace_async(name_of_span="KustoClient.streaming_query", kind=SpanKind.CLIENT)
     @aio_documented_by(KustoClientSync.execute_streaming_query)
     async def execute_streaming_query(
-        self, database: str, query: str, timeout: timedelta = _KustoClientBase._query_default_timeout, properties: Optional[ClientRequestProperties] = None
+        self,
+        database: Optional[str],
+        query: str,
+        timeout: timedelta = _KustoClientBase._query_default_timeout,
+        properties: Optional[ClientRequestProperties] = None,
     ) -> KustoStreamingResponseDataSet:
+        database = self.get_database(database)
         KustoTracingAttributes.set_query_attributes(self._kusto_cluster, database, properties)
 
         response = await self._execute_streaming_query_parsed(database, query, timeout, properties)
@@ -104,7 +116,7 @@ class KustoClient(_KustoClientBase):
     async def _execute(
         self,
         endpoint: str,
-        database: str,
+        database: Optional[str],
         query: Optional[str],
         payload: Optional[io.IOBase],
         timeout: timedelta,

--- a/azure-kusto-data/azure/kusto/data/aio/client.py
+++ b/azure-kusto-data/azure/kusto/data/aio/client.py
@@ -52,7 +52,7 @@ class KustoClient(_KustoClientBase):
     @distributed_trace_async(name_of_span="KustoClient.query_cmd", kind=SpanKind.CLIENT)
     @aio_documented_by(KustoClientSync.execute_query)
     async def execute_query(self, database: Optional[str], query: str, properties: ClientRequestProperties = None) -> KustoResponseDataSet:
-        database = self.get_database(database)
+        database = self._get_database_or_default(database)
         KustoTracingAttributes.set_query_attributes(self._kusto_cluster, database, properties)
 
         return await self._execute(self._query_endpoint, database, query, None, KustoClient._query_default_timeout, properties)
@@ -60,7 +60,7 @@ class KustoClient(_KustoClientBase):
     @distributed_trace_async(name_of_span="KustoClient.control_cmd", kind=SpanKind.CLIENT)
     @aio_documented_by(KustoClientSync.execute_mgmt)
     async def execute_mgmt(self, database: Optional[str], query: str, properties: ClientRequestProperties = None) -> KustoResponseDataSet:
-        database = self.get_database(database)
+        database = self._get_database_or_default(database)
         KustoTracingAttributes.set_query_attributes(self._kusto_cluster, database, properties)
 
         return await self._execute(self._mgmt_endpoint, database, query, None, KustoClient._mgmt_default_timeout, properties)
@@ -76,7 +76,7 @@ class KustoClient(_KustoClientBase):
         properties: ClientRequestProperties = None,
         mapping_name: str = None,
     ):
-        database = self.get_database(database)
+        database = self._get_database_or_default(database)
         KustoTracingAttributes.set_streaming_ingest_attributes(self._kusto_cluster, database, table, properties)
 
         stream_format = stream_format.kusto_value if isinstance(stream_format, DataFormat) else DataFormat[stream_format.upper()].kusto_value
@@ -106,7 +106,7 @@ class KustoClient(_KustoClientBase):
         timeout: timedelta = _KustoClientBase._query_default_timeout,
         properties: Optional[ClientRequestProperties] = None,
     ) -> KustoStreamingResponseDataSet:
-        database = self.get_database(database)
+        database = self._get_database_or_default(database)
         KustoTracingAttributes.set_query_attributes(self._kusto_cluster, database, properties)
 
         response = await self._execute_streaming_query_parsed(database, query, timeout, properties)

--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -170,7 +170,7 @@ class KustoClient(_KustoClientBase):
         :return: Kusto response data set.
         :rtype: azure.kusto.data.response.KustoResponseDataSet
         """
-        database = self.get_database(database)
+        database = self._get_database_or_default(database)
         KustoTracingAttributes.set_query_attributes(self._kusto_cluster, database, properties)
 
         return self._execute(self._query_endpoint, database, query, None, self._query_default_timeout, properties)
@@ -186,7 +186,7 @@ class KustoClient(_KustoClientBase):
         :return: Kusto response data set.
         :rtype: azure.kusto.data.response.KustoResponseDataSet
         """
-        database = self.get_database(database)
+        database = self._get_database_or_default(database)
         KustoTracingAttributes.set_query_attributes(self._kusto_cluster, database, properties)
 
         return self._execute(self._mgmt_endpoint, database, query, None, self._mgmt_default_timeout, properties)
@@ -213,7 +213,7 @@ class KustoClient(_KustoClientBase):
         :param ClientRequestProperties properties: additional request properties.
         :param str mapping_name: Pre-defined mapping of the table. Required when stream_format is json/avro.
         """
-        database = self.get_database(database)
+        database = self._get_database_or_default(database)
         KustoTracingAttributes.set_streaming_ingest_attributes(self._kusto_cluster, database, table, properties)
 
         stream_format = stream_format.kusto_value if isinstance(stream_format, DataFormat) else DataFormat[stream_format.upper()].kusto_value

--- a/azure-kusto-data/azure/kusto/data/client_base.py
+++ b/azure-kusto-data/azure/kusto/data/client_base.py
@@ -45,6 +45,9 @@ class _KustoClientBase(abc.ABC):
         # notice that in this context, federated actually just stands for aad auth, not aad federated auth (legacy code)
         self._aad_helper = _AadHelper(self._kcsb, is_async) if self._kcsb.aad_federated_security else None
 
+        if not self._kusto_cluster.endswith("/"):
+            self._kusto_cluster += "/"
+
         # Create a session object for connection pooling
         self._mgmt_endpoint = urljoin(self._kusto_cluster, "v1/rest/mgmt")
         self._query_endpoint = urljoin(self._kusto_cluster, "v2/rest/query")
@@ -57,6 +60,11 @@ class _KustoClientBase(abc.ABC):
 
         self.client_details = self._kcsb.client_details
         self._is_closed: bool = False
+
+        self.default_database = self._kcsb.initial_catalog
+
+    def get_database(self, database_name: str) -> str:
+        return database_name or self.default_database
 
     def close(self):
         if not self._is_closed:

--- a/azure-kusto-data/azure/kusto/data/client_base.py
+++ b/azure-kusto-data/azure/kusto/data/client_base.py
@@ -63,7 +63,7 @@ class _KustoClientBase(abc.ABC):
 
         self.default_database = self._kcsb.initial_catalog
 
-    def get_database(self, database_name: str) -> str:
+    def _get_database_or_default(self, database_name: Optional[str]) -> str:
         return database_name or self.default_database
 
     def close(self):

--- a/azure-kusto-data/tests/aio/test_async_token_providers.py
+++ b/azure-kusto-data/tests/aio/test_async_token_providers.py
@@ -295,7 +295,7 @@ class TestTokenProvider:
             kusto_service_resource_id="https://fakeurl.kusto.windows.net",
             first_party_authority_url="",
         )
-        CloudSettings._cloud_cache[FAKE_URI] = cloud
+        CloudSettings.add_to_cache(FAKE_URI, cloud)
         authority = "auth_test"
 
         with UserPassTokenProvider(FAKE_URI, authority, "a", "b", is_async=True) as provider:
@@ -317,7 +317,7 @@ class TestTokenProvider:
             kusto_service_resource_id="https://fakeurl.kusto.windows.net",
             first_party_authority_url="",
         )
-        CloudSettings._cloud_cache[FAKE_URI] = cloud
+        CloudSettings.add_to_cache(FAKE_URI, cloud)
         authority = "auth_test"
 
         with UserPassTokenProvider(FAKE_URI, authority, "a", "b", is_async=True) as provider:

--- a/azure-kusto-data/tests/e2e.py
+++ b/azure-kusto-data/tests/e2e.py
@@ -328,9 +328,7 @@ class TestE2E:
     @pytest.mark.parametrize("code", [301, 302, 307, 308])
     async def test_no_redirects_fail_in_cloud(self, code):
         async with AsyncKustoClient(
-            KustoConnectionStringBuilder.with_azure_token_credential(
-                f"https://statusreturner.azurewebsites.net/{code}/nocloud", AsyncDefaultAzureCredential()
-            )
+            KustoConnectionStringBuilder.with_azure_token_credential(f"https://statusreturner.azurewebsites.net/{code}/nocloud", AsyncDefaultAzureCredential())
         ) as client:
             with pytest.raises(KustoServiceError) as ex:
                 await client.execute("db", "table")

--- a/azure-kusto-data/tests/e2e.py
+++ b/azure-kusto-data/tests/e2e.py
@@ -308,7 +308,7 @@ class TestE2E:
     @pytest.mark.parametrize("code", [301, 302, 307, 308])
     def test_no_redirects_fail_in_cloud(self, code):
         with KustoClient(
-            KustoConnectionStringBuilder.with_azure_token_credential(f"https://statusreturner.azurewebsites.net/{code}/nocloud/test", DefaultAzureCredential())
+            KustoConnectionStringBuilder.with_azure_token_credential(f"https://statusreturner.azurewebsites.net/{code}/nocloud", DefaultAzureCredential())
         ) as client:
             with pytest.raises(KustoServiceError) as ex:
                 client.execute("db", "table")
@@ -318,7 +318,7 @@ class TestE2E:
     def test_no_redirects_fail_in_client(self, code):
         well_known_kusto_endpoints.add_trusted_hosts([MatchRule("statusreturner.azurewebsites.net", False)], False)
         with KustoClient(
-            KustoConnectionStringBuilder.with_azure_token_credential(f"https://statusreturner.azurewebsites.net/{code}/test", DefaultAzureCredential())
+            KustoConnectionStringBuilder.with_azure_token_credential(f"https://statusreturner.azurewebsites.net/{code}/segment", DefaultAzureCredential())
         ) as client:
             with pytest.raises(KustoServiceError) as ex:
                 client.execute("db", "table")
@@ -329,7 +329,7 @@ class TestE2E:
     async def test_no_redirects_fail_in_cloud(self, code):
         async with AsyncKustoClient(
             KustoConnectionStringBuilder.with_azure_token_credential(
-                f"https://statusreturner.azurewebsites.net/{code}/nocloud/test", AsyncDefaultAzureCredential()
+                f"https://statusreturner.azurewebsites.net/{code}/nocloud", AsyncDefaultAzureCredential()
             )
         ) as client:
             with pytest.raises(KustoServiceError) as ex:
@@ -341,7 +341,7 @@ class TestE2E:
     async def test_no_redirects_fail_in_client(self, code):
         well_known_kusto_endpoints.add_trusted_hosts([MatchRule("statusreturner.azurewebsites.net", False)], False)
         async with AsyncKustoClient(
-            KustoConnectionStringBuilder.with_azure_token_credential(f"https://statusreturner.azurewebsites.net/{code}/test", AsyncDefaultAzureCredential())
+            KustoConnectionStringBuilder.with_azure_token_credential(f"https://statusreturner.azurewebsites.net/{code}/segment", AsyncDefaultAzureCredential())
         ) as client:
             with pytest.raises(KustoServiceError) as ex:
                 await client.execute("db", "table")

--- a/azure-kusto-data/tests/test_kusto_client.py
+++ b/azure-kusto-data/tests/test_kusto_client.py
@@ -200,36 +200,52 @@ class TestKustoClient(KustoClientTestsMixin):
     def test_proxy_url_parsing(self):
         """Test Proxy URL Parsing"""
         tests = {
-            "https://kusto.test.com": "https://kusto.test.com",
-            "https://kusto.test.com/": "https://kusto.test.com",
-            "https://kusto.test.com/test": "https://kusto.test.com/test",
-            "https://kusto.test.com:4242": "https://kusto.test.com:4242",
-            "https://kusto.test.com:4242/": "https://kusto.test.com:4242",
-            "https://kusto.test.com:4242/test": "https://kusto.test.com:4242/test",
-            "https://kusto.test.com;fed=true": "https://kusto.test.com",
-            "https://kusto.test.com/;fed=true": "https://kusto.test.com",
-            "https://kusto.test.com/test;fed=true": "https://kusto.test.com/test",
-            "https://kusto.test.com:4242;fed=true": "https://kusto.test.com:4242",
-            "https://kusto.test.com:4242/;fed=true": "https://kusto.test.com:4242",
-            "https://kusto.test.com:4242/test;fed=true": "https://kusto.test.com:4242/test",
+            "https://kusto.test.com": ("https://kusto.test.com", "NetDefaultDB"),
+            "https://kusto.test.com/": ("https://kusto.test.com", "NetDefaultDB"),
+            "https://kusto.test.com/test": ("https://kusto.test.com", "test"),
+            "https://kusto.test.com/test/test2": ("https://kusto.test.com/test/test2", "NetDefaultDB"),
+            "https://kusto.test.com:4242": ("https://kusto.test.com:4242", "NetDefaultDB"),
+            "https://kusto.test.com:4242/": ("https://kusto.test.com:4242", "NetDefaultDB"),
+            "https://kusto.test.com:4242/test": ("https://kusto.test.com:4242", "test"),
+            "https://kusto.test.com:4242/test/test2": ("https://kusto.test.com:4242/test/test2", "NetDefaultDB"),
+            "https://kusto.test.com;fed=true": ("https://kusto.test.com", "NetDefaultDB"),
+            "https://kusto.test.com/;fed=true": ("https://kusto.test.com", "NetDefaultDB"),
+            "https://kusto.test.com/test;fed=true": ("https://kusto.test.com", "test"),
+            "https://kusto.test.com/test/test2;fed=true": ("https://kusto.test.com/test/test2", "NetDefaultDB"),
+            "https://kusto.test.com:4242;fed=true": ("https://kusto.test.com:4242", "NetDefaultDB"),
+            "https://kusto.test.com:4242/;fed=true": ("https://kusto.test.com:4242", "NetDefaultDB"),
+            "https://kusto.test.com:4242/test;fed=true": ("https://kusto.test.com:4242", "test"),
+            "https://kusto.test.com:4242/test/test2;fed=true": ("https://kusto.test.com:4242/test/test2", "NetDefaultDB"),
             "https://ade.loganalytics.io/subscriptions/da45f7ac-97c0-4fff-ac66-3b6810eb4f65/resourcegroups"
-            "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace": "https://ade.loganalytics.io/subscriptions/da45f7ac-97c0-4fff-ac66-3b6810eb4f65/resourcegroups"
-            "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace",
+            "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace": (
+                "https://ade.loganalytics.io/subscriptions/da45f7ac-97c0-4fff-ac66-3b6810eb4f65/resourcegroups"
+                "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace",
+                "NetDefaultDB",
+            ),
             "https://ade.loganalytics.io/subscriptions/da45f7ac-97c0-4fff-ac66-3b6810eb4f65/resourcegroups"
-            "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace/": "https://ade.loganalytics.io/subscriptions/da45f7ac-97c0-4fff-ac66-3b6810eb4f65/resourcegroups"
-            "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace",
+            "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace/": (
+                "https://ade.loganalytics.io/subscriptions/da45f7ac-97c0-4fff-ac66-3b6810eb4f65/resourcegroups"
+                "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace",
+                "NetDefaultDB",
+            ),
             "https://ade.loganalytics.io:4242/subscriptions/da45f7ac-97c0-4fff-ac66-3b6810eb4f65/resourcegroups"
-            "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace/": "https://ade.loganalytics.io:4242/subscriptions/da45f7ac-97c0-4fff-ac66-3b6810eb4f65/resourcegroups"
-            "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace",
+            "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace/": (
+                "https://ade.loganalytics.io:4242/subscriptions/da45f7ac-97c0-4fff-ac66-3b6810eb4f65/resourcegroups"
+                "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace",
+                "NetDefaultDB",
+            ),
             "https://ade.loganalytics.io:4242/subscriptions/da45f7ac-97c0-4fff-ac66-3b6810eb4f65/resourcegroups"
-            "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace/;fed=true": "https://ade.loganalytics.io:4242/subscriptions/da45f7ac-97c0-4fff-ac66-3b6810eb4f65"
-            "/resourcegroups/some_resource_group/providers/microsoft.operationalinsights/workspaces"
-            "/some_workspace",
-            "https://kusto.aria.microsoft.com": "https://kusto.aria.microsoft.com",
-            "https://kusto.aria.microsoft.com/": "https://kusto.aria.microsoft.com",
-            "https://kusto.aria.microsoft.com/;fed=true": "https://kusto.aria.microsoft.com",
+            "/some_resource_group/providers/microsoft.operationalinsights/workspaces/some_workspace/;fed=true": (
+                "https://ade.loganalytics.io:4242/subscriptions/da45f7ac-97c0-4fff-ac66-3b6810eb4f65"
+                "/resourcegroups/some_resource_group/providers/microsoft.operationalinsights/workspaces"
+                "/some_workspace",
+                "NetDefaultDB",
+            ),
+            "https://kusto.aria.microsoft.com": ("https://kusto.aria.microsoft.com", "NetDefaultDB"),
+            "https://kusto.aria.microsoft.com/": ("https://kusto.aria.microsoft.com", "NetDefaultDB"),
+            "https://kusto.aria.microsoft.com/;fed=true": ("https://kusto.aria.microsoft.com", "NetDefaultDB"),
         }
 
-        for actual_url, expected_url in tests.items():
+        for actual_url, expected in tests.items():
             kcsb = KustoConnectionStringBuilder(actual_url)
-            assert kcsb.data_source == expected_url
+            assert (kcsb.data_source, kcsb.initial_catalog) == expected

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -3,7 +3,7 @@
 import unittest
 from uuid import uuid4
 
-from azure.kusto.data import KustoConnectionStringBuilder
+from azure.kusto.data import KustoConnectionStringBuilder, KustoClient
 
 
 class KustoConnectionStringBuilderTests(unittest.TestCase):
@@ -28,8 +28,8 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
             assert kcsb.application_client_id is None
             assert kcsb.application_key is None
             assert kcsb.authority_id == "organizations"
-            assert repr(kcsb) == "Data Source=localhost;Authority Id=organizations"
-            assert str(kcsb) == "Data Source=localhost;Authority Id=organizations"
+            assert repr(kcsb) == "Data Source=localhost;Initial Catalog=NetDefaultDB;Authority Id=organizations"
+            assert str(kcsb) == "Data Source=localhost;Initial Catalog=NetDefaultDB;Authority Id=organizations"
 
     def test_aad_app(self):
         """Checks kcsb that is created with AAD application credentials."""
@@ -85,11 +85,15 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
             assert kcsb.application_client_id == uuid
             assert kcsb.application_key == key
             assert kcsb.authority_id == "microsoft.com"
-            assert repr(kcsb) == "Data Source=localhost;AAD Federated Security=True;Application Client Id={0};Application Key={1};Authority Id={2}".format(
+            assert repr(
+                kcsb
+            ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Application Client Id={0};Application Key={1};Authority Id={2}".format(
                 uuid, key, "microsoft.com"
             )
 
-            assert str(kcsb) == "Data Source=localhost;AAD Federated Security=True;Application Client Id={0};Application Key={1};Authority Id={2}".format(
+            assert str(
+                kcsb
+            ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Application Client Id={0};Application Key={1};Authority Id={2}".format(
                 uuid, self.PASSWORDS_REPLACEMENT, "microsoft.com"
             )
 
@@ -125,10 +129,14 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
             assert kcsb.application_client_id is None
             assert kcsb.application_key is None
             assert kcsb.authority_id == "organizations"
-            assert repr(kcsb) == "Data Source=localhost;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=organizations".format(
+            assert repr(
+                kcsb
+            ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=organizations".format(
                 user, password
             )
-            assert str(kcsb) == "Data Source=localhost;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=organizations".format(
+            assert str(
+                kcsb
+            ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=organizations".format(
                 user, self.PASSWORDS_REPLACEMENT
             )
 
@@ -147,8 +155,14 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
         assert kcsb.application_client_id is None
         assert kcsb.application_key is None
         assert kcsb.authority_id == authority_id
-        assert repr(kcsb) == "Data Source=localhost;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=13456".format(user, password)
-        assert str(kcsb) == "Data Source=localhost;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=13456".format(
+        assert repr(
+            kcsb
+        ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=13456".format(
+            user, password
+        )
+        assert str(
+            kcsb
+        ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=13456".format(
             user, self.PASSWORDS_REPLACEMENT
         )
 
@@ -162,8 +176,8 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
         assert kcsb.application_client_id is None
         assert kcsb.application_key is None
         assert kcsb.authority_id == "organizations"
-        assert repr(kcsb) == "Data Source=localhost;AAD Federated Security=True;Authority Id=organizations"
-        assert str(kcsb) == "Data Source=localhost;AAD Federated Security=True;Authority Id=organizations"
+        assert repr(kcsb) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations"
+        assert str(kcsb) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations"
 
     def test_aad_app_token(self):
         """Checks kcsb that is created with AAD user token."""
@@ -178,8 +192,15 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
         assert kcsb.application_key is None
         assert kcsb.user_token is None
         assert kcsb.authority_id == "organizations"
-        assert repr(kcsb) == "Data Source=localhost;AAD Federated Security=True;Authority Id=organizations;Application Token=%s" % token
-        assert str(kcsb) == "Data Source=localhost;AAD Federated Security=True;Authority Id=organizations;Application Token=%s" % self.PASSWORDS_REPLACEMENT
+        assert (
+            repr(kcsb)
+            == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;Application Token=%s" % token
+        )
+        assert (
+            str(kcsb)
+            == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;Application Token=%s"
+            % self.PASSWORDS_REPLACEMENT
+        )
 
     def test_aad_user_token(self):
         """Checks kcsb that is created with AAD user token."""
@@ -194,8 +215,12 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
         assert kcsb.application_key is None
         assert kcsb.application_token is None
         assert kcsb.authority_id == "organizations"
-        assert repr(kcsb) == "Data Source=localhost;AAD Federated Security=True;Authority Id=organizations;User Token=%s" % token
-        assert str(kcsb) == "Data Source=localhost;AAD Federated Security=True;Authority Id=organizations;User Token=%s" % self.PASSWORDS_REPLACEMENT
+        assert repr(kcsb) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;User Token=%s" % token
+        assert (
+            str(kcsb)
+            == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;User Token=%s"
+            % self.PASSWORDS_REPLACEMENT
+        )
 
     def test_add_msi(self):
         client_guid = "kjhjk"
@@ -300,3 +325,43 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
             exception_occurred = True
         finally:
             assert exception_occurred
+
+    def test_initial_catalog_default(self):
+        kcsb = KustoConnectionStringBuilder.with_az_cli_authentication("https://help.kusto.windows.net")
+        assert kcsb.data_source == "https://help.kusto.windows.net"
+        assert kcsb.initial_catalog == "NetDefaultDB"
+        client = KustoClient(kcsb)
+        assert client._kusto_cluster == "https://help.kusto.windows.net/"
+        assert client.default_database == "NetDefaultDB"
+
+    def test_initial_catalog(self):
+        kcsb = KustoConnectionStringBuilder.with_az_cli_authentication("Data Source=https://help.kusto.windows.net;Initial Catalog=Test")
+        assert kcsb.data_source == "https://help.kusto.windows.net"
+        assert kcsb.initial_catalog == "Test"
+        client = KustoClient(kcsb)
+        assert client._kusto_cluster == "https://help.kusto.windows.net/"
+        assert client.default_database == "Test"
+
+    def test_initial_catalog_in_url(self):
+        kcsb = KustoConnectionStringBuilder.with_az_cli_authentication("https://help.kusto.windows.net/Test")
+        assert kcsb.data_source == "https://help.kusto.windows.net"
+        assert kcsb.initial_catalog == "Test"
+        client = KustoClient(kcsb)
+        assert client._kusto_cluster == "https://help.kusto.windows.net/"
+        assert client.default_database == "Test"
+
+    def test_initial_catalog_explicit_overrides_url(self):
+        kcsb = KustoConnectionStringBuilder.with_az_cli_authentication("https://help.kusto.windows.net/Test/;Initial Catalog=Test2")
+        assert kcsb.data_source == "https://help.kusto.windows.net"
+        assert kcsb.initial_catalog == "Test2"
+        client = KustoClient(kcsb)
+        assert client._kusto_cluster == "https://help.kusto.windows.net/"
+        assert client.default_database == "Test2"
+
+    def test_url_with_multiple_paths_does_not_set_db(self):
+        kcsb = KustoConnectionStringBuilder.with_az_cli_authentication("https://help.kusto.windows.net/Test/Test2")
+        assert kcsb.data_source == "https://help.kusto.windows.net/Test/Test2"
+        assert kcsb.initial_catalog == "NetDefaultDB"
+        client = KustoClient(kcsb)
+        assert client._kusto_cluster == "https://help.kusto.windows.net/Test/Test2/"
+        assert client.default_database == "NetDefaultDB"

--- a/azure-kusto-data/tests/test_security.py
+++ b/azure-kusto-data/tests/test_security.py
@@ -10,8 +10,8 @@ from azure.kusto.data.security import _AadHelper
 KUSTO_TEST_URI = "https://thisclusterdoesnotexist.kusto.windows.net"
 TEST_INTERACTIVE_AUTH = False  # User interaction required, enable this when running test manually
 
-CloudSettings._cloud_cache[KUSTO_TEST_URI] = CloudSettings.DEFAULT_CLOUD
-CloudSettings._cloud_cache["https://somecluster.kusto.windows.net"] = CloudSettings.DEFAULT_CLOUD
+CloudSettings.add_to_cache(KUSTO_TEST_URI, CloudSettings.DEFAULT_CLOUD)
+CloudSettings.add_to_cache("https://somecluster.kusto.windows.net", CloudSettings.DEFAULT_CLOUD)
 
 
 def test_unauthorized_exception():

--- a/azure-kusto-data/tests/test_token_providers.py
+++ b/azure-kusto-data/tests/test_token_providers.py
@@ -328,7 +328,7 @@ class TokenProviderTests(unittest.TestCase):
             kusto_service_resource_id="https://fakeurl.kusto.windows.net",
             first_party_authority_url="",
         )
-        CloudSettings._cloud_cache[FAKE_URI] = cloud
+        CloudSettings.add_to_cache(FAKE_URI, cloud)
         authority = "auth_test"
 
         with UserPassTokenProvider(FAKE_URI, authority, "a", "b") as provider:
@@ -349,7 +349,7 @@ class TokenProviderTests(unittest.TestCase):
             kusto_service_resource_id="https://fakeurl.kusto.windows.net",
             first_party_authority_url="",
         )
-        CloudSettings._cloud_cache[FAKE_URI] = cloud
+        CloudSettings.add_to_cache(FAKE_URI, cloud)
         authority = "auth_test"
 
         with UserPassTokenProvider(FAKE_URI, authority, "a", "b") as provider:


### PR DESCRIPTION
### Added
- Added Initial Catalog (Default Database) parameter to ConnectionStringBuilder
- Added method to manually set the cache for CloudSettings
### Changed
- Urls with one item after the path (i.e https://test.com/abc) will now be treated as cluster and initial catalog (ie. the cluster is "https://test.com" and the initial catalog is "abc").
    * This is to align our behaviour with the .NET SDK
### Fixed
- Some edge cases in url parsing