### PR TITLE
Sanitize secrets from blob URL by removing semicolon parameters

### DIFF
--- a/azure-kusto-ingest/azure/kusto/ingest/base_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/base_ingest_client.py
@@ -61,7 +61,7 @@ class IngestionResult:
     def __repr__(self):
         # Remove query parameters from blob_uri, if exists
         if isinstance(self.blob_uri, str):
-            obfuscated_path = self.blob_uri.split("?")[0]
+            obfuscated_path = self.blob_uri.split("?")[0].split(";")[0]
         return f"IngestionResult(status={self.status}, database={self.database}, table={self.table}, source_id={self.source_id}, blob_uri={obfuscated_path})"
 
 

--- a/azure-kusto-ingest/azure/kusto/ingest/descriptors.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/descriptors.py
@@ -183,7 +183,7 @@ class BlobDescriptor(DescriptorBase):
     def get_tracing_attributes(self) -> dict:
         # Remove query parameters from self.path, if exists
         if self.path:
-            obfuscated_path = self.path.split("?")[0]
+            obfuscated_path = self.path.split("?")[0].split(";")[0]
         return {self._BLOB_URI: obfuscated_path, self._SOURCE_ID: str(self.source_id)}
 
 


### PR DESCRIPTION
#### Pull Request Description

Sanitize secrets from blob URL by removing semicolon parameters (previously only removed query parameters)

---

#### Future Release Comment
**Features:**
- Sanitize secrets from blob URL by removing semicolon parameters (previously only removed query parameters)