### PR TITLE
Fix closing of async token providers

### DIFF
--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -29,13 +29,10 @@ DeviceCallbackType = Callable[[str, str, datetime], None]
         If this argument isn't provided, the credential will print instructions to stdout."""
 
 try:
-    from asgiref.sync import sync_to_async, async_to_sync
+    from asgiref.sync import sync_to_async
 except ImportError:
 
     def sync_to_async(f):
-        raise KustoAioSyntaxError()
-
-    def async_to_sync(f):
         raise KustoAioSyntaxError()
 
 
@@ -103,6 +100,9 @@ class TokenProviderBase(abc.ABC):
             self._lock = Lock()
 
     def close(self):
+        pass
+
+    async def close_async(self):
         pass
 
     def _init_once(self, init_only_resources=False):
@@ -203,6 +203,12 @@ class TokenProviderBase(abc.ABC):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close_async()
 
     @staticmethod
     @abc.abstractmethod
@@ -395,8 +401,15 @@ class MsiTokenProvider(CloudInfoTokenProvider):
     def close(self):
         if self._msi_auth_context is not None:
             self._msi_auth_context.close()
+        if self._msi_auth_context is not None:
+            raise KustoAsyncUsageError("Can't close async token provider with sync close", self.is_async)
+
+    async def close_async(self):
+        if self._msi_auth_context is not None:
+            sync_to_async(self._msi_auth_context.close())
+
         if self._msi_auth_context_async is not None:
-            async_to_sync(self._msi_auth_context_async.close)()
+            await self._msi_auth_context_async.close()
 
 
 class AzCliTokenProvider(CloudInfoTokenProvider):
@@ -455,7 +468,14 @@ class AzCliTokenProvider(CloudInfoTokenProvider):
         if self._az_auth_context is not None:
             self._az_auth_context.close()
         if self._az_auth_context_async is not None:
-            async_to_sync(self._az_auth_context_async.close())
+            raise KustoAsyncUsageError("Can't close async token provider with sync close", self.is_async)
+
+    async def close_async(self):
+        if self._az_auth_context is not None:
+            sync_to_async(self._az_auth_context.close())
+
+        if self._az_auth_context_async is not None:
+            await self._az_auth_context_async.close()
 
 
 class UserPassTokenProvider(CloudInfoTokenProvider):
@@ -665,10 +685,19 @@ class AzureIdentityTokenCredentialProvider(CloudInfoTokenProvider):
 
     def close(self):
         if self.credential is not None:
-            if self.is_async:
-                async_to_sync(self.credential.close)()
+            if inspect.iscoroutinefunction(self.credential.close):
+                raise KustoAsyncUsageError("Can't close async token provider with sync close", self.is_async)
             else:
                 self.credential.close()
+            self.credential = None
+            self.credential_from_login_endpoint = None
+
+    async def close_async(self):
+        if self.credential is not None:
+            if inspect.iscoroutinefunction(self.credential.close):
+                await self.credential.close()
+            else:
+                sync_to_async(self.credential.close)()
             self.credential = None
             self.credential_from_login_endpoint = None
 

--- a/azure-kusto-data/azure/kusto/data/aio/client.py
+++ b/azure-kusto-data/azure/kusto/data/aio/client.py
@@ -37,6 +37,8 @@ class KustoClient(_KustoClientBase):
     async def close(self):
         if not self._is_closed:
             await self._session.close()
+            if self._aad_helper:
+                await self._aad_helper.close_async()
         super().close()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -83,6 +83,8 @@ class KustoClient(_KustoClientBase):
     def close(self):
         if not self._is_closed:
             self._session.close()
+            if self._aad_helper:
+                self._aad_helper.close()
         super().close()
 
     def __enter__(self):

--- a/azure-kusto-data/azure/kusto/data/client_base.py
+++ b/azure-kusto-data/azure/kusto/data/client_base.py
@@ -67,9 +67,6 @@ class _KustoClientBase(abc.ABC):
         return database_name or self.default_database
 
     def close(self):
-        if not self._is_closed:
-            if self._aad_helper is not None:
-                self._aad_helper.close()
         self._is_closed = True
 
     def set_proxy(self, proxy_url: str):

--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -96,6 +96,9 @@ class _AadHelper:
     def close(self):
         self.token_provider.close()
 
+    async def close_async(self):
+        await self.token_provider.close_async()
+
 
 def _get_header_from_dict(token: dict):
     if TokenConstants.MSAL_ACCESS_TOKEN in token:

--- a/azure-kusto-data/tests/aio/test_async_token_providers.py
+++ b/azure-kusto-data/tests/aio/test_async_token_providers.py
@@ -5,7 +5,7 @@ from azure.identity.aio import ClientSecretCredential as AsyncClientSecretCreden
 
 from azure.kusto.data._decorators import aio_documented_by
 from azure.kusto.data._token_providers import *
-from azure.kusto.data.env_utils import get_env, get_app_id, get_auth_id, get_app_key, prepare_app_key_auth
+from azure.kusto.data.env_utils import get_env, get_app_id, get_auth_id, prepare_app_key_auth
 from .test_kusto_client import run_aio_tests
 from ..test_token_providers import KUSTO_URI, TOKEN_VALUE, TEST_AZ_AUTH, TEST_MSI_AUTH, TEST_DEVICE_AUTH, TokenProviderTests, MockProvider
 
@@ -145,7 +145,7 @@ class TestTokenProvider:
             pytest.skip(" *** Skipped Az-Cli Provider Test ***")
 
         print("Note!\nThe test 'test_az_provider' will fail if 'az login' was not called.")
-        with AzCliTokenProvider(KUSTO_URI, is_async=True) as provider:
+        async with AzCliTokenProvider(KUSTO_URI, is_async=True) as provider:
             token = await provider.get_token_async()
             assert self.get_token_value(token) is not None
 
@@ -163,25 +163,25 @@ class TestTokenProvider:
         user_msi_client_id = get_env("MSI_CLIENT_ID", optional=True)
 
         # system MSI
-        with MsiTokenProvider(KUSTO_URI, is_async=True) as provider:
+        async with MsiTokenProvider(KUSTO_URI, is_async=True) as provider:
             token = await provider.get_token_async()
             assert self.get_token_value(token) is not None
 
-            if user_msi_object_id is not None:
-                args = {"object_id": user_msi_object_id}
-                with MsiTokenProvider(KUSTO_URI, args, is_async=True) as provider:
-                    token = await provider.get_token_async()
-                    assert self.get_token_value(token) is not None
-            else:
-                pytest.skip(" *** Skipped MSI Provider Client Id Test ***")
+        if user_msi_object_id is not None:
+            args = {"object_id": user_msi_object_id}
+            async with MsiTokenProvider(KUSTO_URI, args, is_async=True) as provider:
+                token = await provider.get_token_async()
+                assert self.get_token_value(token) is not None
+        else:
+            pytest.skip(" *** Skipped MSI Provider Client Id Test ***")
 
-            if user_msi_client_id is not None:
-                args = {"client_id": user_msi_client_id}
-                with MsiTokenProvider(KUSTO_URI, args, is_async=True) as provider:
-                    token = await provider.get_token_async()
-                    assert self.get_token_value(token) is not None
-            else:
-                pytest.skip(" *** Skipped MSI Provider Object Id Test ***")
+        if user_msi_client_id is not None:
+            args = {"client_id": user_msi_client_id}
+            async with MsiTokenProvider(KUSTO_URI, args, is_async=True) as provider:
+                token = await provider.get_token_async()
+                assert self.get_token_value(token) is not None
+        else:
+            pytest.skip(" *** Skipped MSI Provider Object Id Test ***")
 
     @aio_documented_by(TokenProviderTests.test_user_pass_provider)
     @pytest.mark.asyncio
@@ -339,11 +339,11 @@ class TestTokenProvider:
         if not app_id or not app_key or not auth_id:
             pytest.skip(" *** Skipped Azure Identity Provider Test ***")
 
-        with AzureIdentityTokenCredentialProvider(KUSTO_URI, is_async=True, credential=AsyncDefaultAzureCredential()) as provider:
+        async with AzureIdentityTokenCredentialProvider(KUSTO_URI, is_async=True, credential=AsyncDefaultAzureCredential()) as provider:
             token = await provider.get_token_async()
             assert TokenProviderTests.get_token_value(token) is not None
 
-        with AzureIdentityTokenCredentialProvider(
+        async with AzureIdentityTokenCredentialProvider(
             KUSTO_URI,
             is_async=True,
             credential_from_login_endpoint=lambda login_endpoint: AsyncClientSecretCredential(


### PR DESCRIPTION
### Fixed
* Async token providers are properly closed (#417)
	*  This PR makes using sync clients with async token providers an error (since they can't be properly closed). Is this considered breaking or bug fix?