### PR TITLE
Fix pandas datetime formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## Unreleased
+### Fixed
+- Pandas now correctly parses all dates
+
 ## [4.3.0] - 2023-12-12
 ### Added
 - Added smart retry ability for queued ingestion.

--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -60,7 +60,7 @@ def dataframe_from_result_table(table: "Union[KustoResultTable, KustoStreamingRe
             frame[col.column_name] = frame[col.column_name].replace("NaN", np.NaN).replace("Infinity", np.PINF).replace("-Infinity", np.NINF)
             frame[col.column_name] = pd.to_numeric(frame[col.column_name], errors="coerce").astype(pd.Float64Dtype())
         elif col.column_type == "datetime":
-            frame[col.column_name] = pd.to_datetime(frame[col.column_name], errors="coerce")
+            frame[col.column_name] = pd.to_datetime(frame[col.column_name], format="ISO8601", utc=True)
         elif col.column_type == "timespan":
             frame[col.column_name] = frame[col.column_name].apply(to_pandas_timedelta)
 

--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -68,8 +68,8 @@ def dataframe_from_result_table(table: "Union[KustoResultTable, KustoStreamingRe
             else:
                 # if frame contains ".", replace "Z" with ".000Z"
                 # == False is not a mistake - that's the pandas way to do it
-                not_contains_dot = frame[col.column_name].str.contains(".") == False
-                frame.loc[not_contains_dot, col.column_name] = frame.loc[not_contains_dot, col.column_name].str.replace("Z", ".000Z")
+                contains_dot = frame[col.column_name].str.contains(".")
+                frame.loc[contains_dot == False, col.column_name] = frame.loc[contains_dot == False, col.column_name].str.replace("Z", ".000Z")
             frame[col.column_name] = pd.to_datetime(frame[col.column_name], errors="coerce", **args)
         elif col.column_type == "timespan":
             frame[col.column_name] = frame[col.column_name].apply(to_pandas_timedelta)

--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -60,7 +60,7 @@ def dataframe_from_result_table(table: "Union[KustoResultTable, KustoStreamingRe
             frame[col.column_name] = frame[col.column_name].replace("NaN", np.NaN).replace("Infinity", np.PINF).replace("-Infinity", np.NINF)
             frame[col.column_name] = pd.to_numeric(frame[col.column_name], errors="coerce").astype(pd.Float64Dtype())
         elif col.column_type == "datetime":
-            frame[col.column_name] = pd.to_datetime(frame[col.column_name], format="ISO8601", utc=True)
+            frame[col.column_name] = pd.to_datetime(frame[col.column_name], format="ISO8601", utc=True, errors="coerce")
         elif col.column_type == "timespan":
             frame[col.column_name] = frame[col.column_name].apply(to_pandas_timedelta)
 

--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -66,8 +66,10 @@ def dataframe_from_result_table(table: "Union[KustoResultTable, KustoStreamingRe
             if pd.__version__.startswith("2."):
                 args = {"format": "ISO8601", "utc": True}
             else:
-                # Manually add microseconds to the format string
-                frame[col.column_name] = frame[col.column_name].str.replace(r"(:\d+)Z$", r"\1.000Z")
+                # if frame contains ".", replace "Z" with ".000Z"
+                # == False is not a mistake - that's the pandas way to do it
+                not_contains_dot = frame[col.column_name].str.contains(".") == False
+                frame.loc[not_contains_dot, col.column_name] = frame.loc[not_contains_dot, col.column_name].str.replace("Z", ".000Z")
             frame[col.column_name] = pd.to_datetime(frame[col.column_name], errors="coerce", **args)
         elif col.column_type == "timespan":
             frame[col.column_name] = frame[col.column_name].apply(to_pandas_timedelta)

--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -1,3 +1,4 @@
+import sys
 from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
@@ -60,7 +61,14 @@ def dataframe_from_result_table(table: "Union[KustoResultTable, KustoStreamingRe
             frame[col.column_name] = frame[col.column_name].replace("NaN", np.NaN).replace("Infinity", np.PINF).replace("-Infinity", np.NINF)
             frame[col.column_name] = pd.to_numeric(frame[col.column_name], errors="coerce").astype(pd.Float64Dtype())
         elif col.column_type == "datetime":
-            frame[col.column_name] = pd.to_datetime(frame[col.column_name], format="ISO8601", utc=True, errors="coerce")
+            # Pandas before version 2 doesn't support the "format" arg
+            args = {}
+            if pd.__version__.startswith("2."):
+                args = {"format": "ISO8601", "utc": True}
+            else:
+                # Manually add microseconds to the format string
+                frame[col.column_name] = frame[col.column_name].str.replace(r"(:\d+)Z$", r"\1.000Z")
+            frame[col.column_name] = pd.to_datetime(frame[col.column_name], errors="coerce", **args)
         elif col.column_type == "timespan":
             frame[col.column_name] = frame[col.column_name].apply(to_pandas_timedelta)
 

--- a/azure-kusto-data/tests/test_helpers.py
+++ b/azure-kusto-data/tests/test_helpers.py
@@ -3,74 +3,80 @@
 
 import json
 import os
-import pytest
 
+from azure.kusto.data._models import KustoResultTable
 from azure.kusto.data.helpers import dataframe_from_result_table
 from azure.kusto.data.response import KustoResponseDataSetV2
+import pandas
+import numpy
 
 
-PANDAS = False
-try:
-    import pandas
-    import numpy
+def test_dataframe_from_result_table():
+    """Test conversion of KustoResultTable to pandas.DataFrame, including fixes for certain column types"""
 
-    PANDAS = True
-except:
-    pass
+    with open(os.path.join(os.path.dirname(__file__), "input", "dataframe.json"), "r") as response_file:
+        data = response_file.read()
+
+    response = KustoResponseDataSetV2(json.loads(data))
+    df = dataframe_from_result_table(response.primary_results[0])
+
+    assert df.iloc[0].RecordName == "now"
+    assert type(df.iloc[0].RecordTime) is pandas._libs.tslibs.timestamps.Timestamp
+    assert all(getattr(df.iloc[0].RecordTime, k) == v for k, v in {"year": 2021, "month": 12, "day": 22, "hour": 11, "minute": 43, "second": 00}.items())
+    assert type(df.iloc[0].RecordBool) is numpy.bool_
+    assert df.iloc[0].RecordBool == True
+    assert type(df.iloc[0].RecordInt) is numpy.int32
+    assert df.iloc[0].RecordInt == 5678
+    assert type(df.iloc[0].RecordReal) is numpy.float64
+    assert df.iloc[0].RecordReal == 3.14159
+
+    # Kusto datetime(0000-01-01T00:00:00Z), which Pandas can't represent.
+    assert df.iloc[1].RecordName == "earliest datetime"
+    assert type(df.iloc[1].RecordTime) is pandas._libs.tslibs.nattype.NaTType
+    assert pandas.isnull(df.iloc[1].RecordReal)
+
+    # Kusto datetime(9999-12-31T23:59:59Z), which Pandas can't represent.
+    assert df.iloc[2].RecordName == "latest datetime"
+    assert type(df.iloc[2].RecordTime) is pandas._libs.tslibs.nattype.NaTType
+    assert type(df.iloc[2].RecordReal) is numpy.float64
+    assert df.iloc[2].RecordReal == numpy.inf
+
+    # Pandas earliest datetime
+    assert df.iloc[3].RecordName == "earliest pandas datetime"
+    assert type(df.iloc[3].RecordTime) is pandas._libs.tslibs.timestamps.Timestamp
+    assert type(df.iloc[3].RecordReal) is numpy.float64
+    assert df.iloc[3].RecordReal == -numpy.inf
+
+    # Pandas latest datetime
+    assert df.iloc[4].RecordName == "latest pandas datetime"
+    assert type(df.iloc[4].RecordTime) is pandas._libs.tslibs.timestamps.Timestamp
+
+    # Kusto 600000000 ticks timedelta
+    assert df.iloc[5].RecordName == "timedelta ticks"
+    assert type(df.iloc[5].RecordTime) is pandas._libs.tslibs.timestamps.Timestamp
+    assert type(df.iloc[5].RecordOffset) is pandas._libs.tslibs.timestamps.Timedelta
+    assert df.iloc[5].RecordOffset == pandas.to_timedelta("00:01:00")
+
+    # Kusto timedelta(1.01:01:01.0) ==
+    assert df.iloc[6].RecordName == "timedelta string"
+    assert type(df.iloc[6].RecordTime) is pandas._libs.tslibs.timestamps.Timestamp
+    assert type(df.iloc[6].RecordOffset) is pandas._libs.tslibs.timestamps.Timedelta
+    assert df.iloc[6].RecordOffset == pandas.to_timedelta("1 days 01:01:01")
 
 
-class TestDataFrameFromResultsTable:
-    """Tests the dataframe_from_result_table helper function"""
-
-    @pytest.mark.skipif(not PANDAS, reason="requires pandas")
-    def test_dataframe_from_result_table(self):
-        """Test conversion of KustoResultTable to pandas.DataFrame, including fixes for certain column types"""
-
-        with open(os.path.join(os.path.dirname(__file__), "input", "dataframe.json"), "r") as response_file:
-            data = response_file.read()
-
-        response = KustoResponseDataSetV2(json.loads(data))
-        df = dataframe_from_result_table(response.primary_results[0])
-
-        assert df.iloc[0].RecordName == "now"
-        assert type(df.iloc[0].RecordTime) is pandas._libs.tslibs.timestamps.Timestamp
-        assert all(getattr(df.iloc[0].RecordTime, k) == v for k, v in {"year": 2021, "month": 12, "day": 22, "hour": 11, "minute": 43, "second": 00}.items())
-        assert type(df.iloc[0].RecordBool) is numpy.bool_
-        assert df.iloc[0].RecordBool == True
-        assert type(df.iloc[0].RecordInt) is numpy.int32
-        assert df.iloc[0].RecordInt == 5678
-        assert type(df.iloc[0].RecordReal) is numpy.float64
-        assert df.iloc[0].RecordReal == 3.14159
-
-        # Kusto datetime(0000-01-01T00:00:00Z), which Pandas can't represent.
-        assert df.iloc[1].RecordName == "earliest datetime"
-        assert type(df.iloc[1].RecordTime) is pandas._libs.tslibs.nattype.NaTType
-        assert pandas.isnull(df.iloc[1].RecordReal)
-
-        # Kusto datetime(9999-12-31T23:59:59Z), which Pandas can't represent.
-        assert df.iloc[2].RecordName == "latest datetime"
-        assert type(df.iloc[2].RecordTime) is pandas._libs.tslibs.nattype.NaTType
-        assert type(df.iloc[2].RecordReal) is numpy.float64
-        assert df.iloc[2].RecordReal == numpy.inf
-
-        # Pandas earliest datetime
-        assert df.iloc[3].RecordName == "earliest pandas datetime"
-        assert type(df.iloc[3].RecordTime) is pandas._libs.tslibs.timestamps.Timestamp
-        assert type(df.iloc[3].RecordReal) is numpy.float64
-        assert df.iloc[3].RecordReal == -numpy.inf
-
-        # Pandas latest datetime
-        assert df.iloc[4].RecordName == "latest pandas datetime"
-        assert type(df.iloc[4].RecordTime) is pandas._libs.tslibs.timestamps.Timestamp
-
-        # Kusto 600000000 ticks timedelta
-        assert df.iloc[5].RecordName == "timedelta ticks"
-        assert type(df.iloc[5].RecordTime) is pandas._libs.tslibs.timestamps.Timestamp
-        assert type(df.iloc[5].RecordOffset) is pandas._libs.tslibs.timestamps.Timedelta
-        assert df.iloc[5].RecordOffset == pandas.to_timedelta("00:01:00")
-
-        # Kusto timedelta(1.01:01:01.0) ==
-        assert df.iloc[6].RecordName == "timedelta string"
-        assert type(df.iloc[6].RecordTime) is pandas._libs.tslibs.timestamps.Timestamp
-        assert type(df.iloc[6].RecordOffset) is pandas._libs.tslibs.timestamps.Timedelta
-        assert df.iloc[6].RecordOffset == pandas.to_timedelta("1 days 01:01:01")
+def test_pandas_mixed_date():
+    df = dataframe_from_result_table(KustoResultTable(
+        {
+            "TableName": "Table_0",
+            "Columns": [
+                {"ColumnName": "Date", "ColumnType": "datetime"},
+            ],
+            "Rows": [
+                ["2023-12-12T01:59:59.352"],
+                ["2023-12-12T01:54:44Z"],
+            ],
+        }
+    ))
+    
+    assert df["Date"][0] == pandas.Timestamp("2023-12-12T01:59:59.352", tz="UTC")
+    assert df["Date"][1] == pandas.Timestamp("2023-12-12T01:54:44Z", tz="UTC")

--- a/azure-kusto-data/tests/test_helpers.py
+++ b/azure-kusto-data/tests/test_helpers.py
@@ -65,18 +65,20 @@ def test_dataframe_from_result_table():
 
 
 def test_pandas_mixed_date():
-    df = dataframe_from_result_table(KustoResultTable(
-        {
-            "TableName": "Table_0",
-            "Columns": [
-                {"ColumnName": "Date", "ColumnType": "datetime"},
-            ],
-            "Rows": [
-                ["2023-12-12T01:59:59.352"],
-                ["2023-12-12T01:54:44Z"],
-            ],
-        }
-    ))
-    
+    df = dataframe_from_result_table(
+        KustoResultTable(
+            {
+                "TableName": "Table_0",
+                "Columns": [
+                    {"ColumnName": "Date", "ColumnType": "datetime"},
+                ],
+                "Rows": [
+                    ["2023-12-12T01:59:59.352"],
+                    ["2023-12-12T01:54:44Z"],
+                ],
+            }
+        )
+    )
+
     assert df["Date"][0] == pandas.Timestamp("2023-12-12T01:59:59.352", tz="UTC")
     assert df["Date"][1] == pandas.Timestamp("2023-12-12T01:54:44Z", tz="UTC")

--- a/azure-kusto-data/tests/test_helpers.py
+++ b/azure-kusto-data/tests/test_helpers.py
@@ -80,5 +80,5 @@ def test_pandas_mixed_date():
         )
     )
 
-    assert df["Date"][0] == pandas.Timestamp("2023-12-12T01:59:59.352", tz="UTC")
+    assert df["Date"][0] == pandas.Timestamp("2023-12-12T01:59:59.352Z", tz="UTC")
     assert df["Date"][1] == pandas.Timestamp("2023-12-12T01:54:44Z", tz="UTC")

--- a/azure-kusto-data/tests/test_helpers.py
+++ b/azure-kusto-data/tests/test_helpers.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License
-
+import datetime
 import json
 import os
 
@@ -80,5 +80,5 @@ def test_pandas_mixed_date():
         )
     )
 
-    assert df["Date"][0] == pandas.Timestamp("2023-12-12T01:59:59.352Z", tz="UTC")
-    assert df["Date"][1] == pandas.Timestamp("2023-12-12T01:54:44Z", tz="UTC")
+    assert df["Date"][0] == pandas.Timestamp(year=2023, month=12, day=12, hour=1, minute=59, second=59, microsecond=352000, tzinfo=datetime.timezone.utc)
+    assert df["Date"][1] == pandas.Timestamp(year=2023, month=12, day=12, hour=1, minute=54, second=44, tzinfo=datetime.timezone.utc)

--- a/azure-kusto-data/tests/test_helpers.py
+++ b/azure-kusto-data/tests/test_helpers.py
@@ -73,7 +73,7 @@ def test_pandas_mixed_date():
                     {"ColumnName": "Date", "ColumnType": "datetime"},
                 ],
                 "Rows": [
-                    ["2023-12-12T01:59:59.352"],
+                    ["2023-12-12T01:59:59.352Z"],
                     ["2023-12-12T01:54:44Z"],
                 ],
             }

--- a/azure-kusto-data/tests/test_kusto_client.py
+++ b/azure-kusto-data/tests/test_kusto_client.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License
 import sys
 
+import pandas
 import pytest
 from mock import patch
 
@@ -11,14 +12,6 @@ from azure.kusto.data.exceptions import KustoClosedError, KustoMultiApiError, Ku
 from azure.kusto.data.helpers import dataframe_from_result_table
 from azure.kusto.data.response import KustoStreamingResponseDataSet
 from tests.kusto_client_common import KustoClientTestsMixin, mocked_requests_post, get_response_first_primary_result, get_table_first_row, proxy_kcsb
-
-PANDAS = False
-try:
-    import pandas
-
-    PANDAS = True
-except:
-    pass
 
 
 @pytest.fixture(params=[KustoClient.execute_query, KustoClient.execute_streaming_query])
@@ -58,7 +51,6 @@ class TestKustoClient(KustoClientTestsMixin):
             response = client.execute_mgmt("NetDefaultDB", ".show version")
             self._assert_sanity_control_command_response(response)
 
-    @pytest.mark.skipif(not PANDAS, reason="requires pandas")
     @patch("requests.Session.post", side_effect=mocked_requests_post)
     def test_sanity_data_frame(self, mock_post, method):
         """Tests KustoResponse to pandas.DataFrame."""
@@ -67,7 +59,6 @@ class TestKustoClient(KustoClientTestsMixin):
             data_frame = dataframe_from_result_table(get_response_first_primary_result(response))
             self._assert_sanity_data_frame_response(data_frame)
 
-    @pytest.mark.skipif(not PANDAS, reason="requires pandas")
     @patch("requests.Session.post", side_effect=mocked_requests_post)
     def test_pandas_bool(self, mock_post):
         """Tests KustoResponse to pandas.DataFrame."""


### PR DESCRIPTION
### Fixed
- Pandas now correctly parses all dates #514 


Changes in the test file:
- Removing the test class (not needed in pytest)
- Removing the test optionality (dev_dependencies always installs pandas)
- Added new test