### PR TITLE
use new unittest.mock everywhere

### DIFF
--- a/azure-kusto-data/tests/test_kusto_client.py
+++ b/azure-kusto-data/tests/test_kusto_client.py
@@ -1,10 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License
 import sys
+from unittest.mock import patch
 
 import pandas
 import pytest
-from mock import patch
 
 from azure.kusto.data import ClientRequestProperties, KustoClient, KustoConnectionStringBuilder
 from azure.kusto.data._cloud_settings import CloudSettings

--- a/azure-kusto-data/tox.ini
+++ b/azure-kusto-data/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27,py35,py37
 
 [testenv]
-deps=mock
+deps=
     pytest
     pandas
 commands = pytest

--- a/azure-kusto-ingest/tests/test_kusto_ingest_client.py
+++ b/azure-kusto-ingest/tests/test_kusto_ingest_client.py
@@ -5,10 +5,10 @@ import json
 import os
 import uuid
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import responses
-from mock import patch
 
 from azure.kusto.data.data_format import DataFormat
 

--- a/azure-kusto-ingest/tests/test_managed_streaming_ingest.py
+++ b/azure-kusto-ingest/tests/test_managed_streaming_ingest.py
@@ -3,10 +3,10 @@ import json
 import os
 import uuid
 from tempfile import NamedTemporaryFile
+from unittest.mock import patch
 
 import pytest
 import responses
-from mock import patch
 
 from azure.kusto.data.data_format import DataFormat
 from azure.kusto.data.exceptions import KustoApiError

--- a/azure-kusto-ingest/tests/test_status_q.py
+++ b/azure-kusto-ingest/tests/test_status_q.py
@@ -3,9 +3,9 @@
 import json
 import time
 import unittest
+from unittest import mock
 from uuid import uuid4
 
-import mock
 from azure.storage.queue import QueueMessage, QueueClient
 
 from azure.kusto.ingest import QueuedIngestClient

--- a/azure-kusto-ingest/tox.ini
+++ b/azure-kusto-ingest/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27,py35,py37
 
 [testenv]
-deps=mock
+deps=
     pytest
     pandas
 commands=pytest

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,4 @@
 pytest>=3.2.0
-mock>=5.1.0
 responses>=0.9.0
 pandas>=0.24.0
 black;python_version >= '3.6'


### PR DESCRIPTION
It is already used in one location:

`azure-kusto-data/tests/aio/test_kusto_client.py:from unittest.mock import patch`

The old 'mock' module is deprecated
