### PR TITLE
Small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Managed streaming fallback to queued
-- 
+- Fixed token providers not being closed properly
+- Internal test fixes
+
 ### Changed
 - Changed binary files data format compression to false
 

--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -406,7 +406,7 @@ class MsiTokenProvider(CloudInfoTokenProvider):
 
     async def close_async(self):
         if self._msi_auth_context is not None:
-            await (sync_to_async(self._msi_auth_context.close()))
+            await sync_to_async(self._msi_auth_context.close())
 
         if self._msi_auth_context_async is not None:
             await self._msi_auth_context_async.close()

--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -406,7 +406,7 @@ class MsiTokenProvider(CloudInfoTokenProvider):
 
     async def close_async(self):
         if self._msi_auth_context is not None:
-            sync_to_async(self._msi_auth_context.close())
+            await (sync_to_async(self._msi_auth_context.close()))
 
         if self._msi_auth_context_async is not None:
             await self._msi_auth_context_async.close()

--- a/azure-kusto-data/azure/kusto/data/_token_providers.py
+++ b/azure-kusto-data/azure/kusto/data/_token_providers.py
@@ -472,7 +472,7 @@ class AzCliTokenProvider(CloudInfoTokenProvider):
 
     async def close_async(self):
         if self._az_auth_context is not None:
-            sync_to_async(self._az_auth_context.close())
+            await sync_to_async(self._az_auth_context.close())
 
         if self._az_auth_context_async is not None:
             await self._az_auth_context_async.close()
@@ -697,7 +697,7 @@ class AzureIdentityTokenCredentialProvider(CloudInfoTokenProvider):
             if inspect.iscoroutinefunction(self.credential.close):
                 await self.credential.close()
             else:
-                sync_to_async(self.credential.close)()
+                await sync_to_async(self.credential.close)()
             self.credential = None
             self.credential_from_login_endpoint = None
 

--- a/azure-kusto-data/tests/aio/test_async_token_providers.py
+++ b/azure-kusto-data/tests/aio/test_async_token_providers.py
@@ -335,9 +335,11 @@ class TestTokenProvider:
     @aio_documented_by(TokenProviderTests.test_azure_identity_default_token_provider)
     @pytest.mark.asyncio
     async def test_azure_identity_token_provider(self):
-        app_id, app_key, auth_id = prepare_app_key_auth(optional=True)
-        if not app_id or not app_key or not auth_id:
+        auth = prepare_app_key_auth(optional=True)
+        if not auth:
             pytest.skip(" *** Skipped Azure Identity Provider Test ***")
+
+        app_id, app_key, auth_id = auth
 
         async with AzureIdentityTokenCredentialProvider(KUSTO_URI, is_async=True, credential=AsyncDefaultAzureCredential()) as provider:
             token = await provider.get_token_async()

--- a/azure-kusto-data/tests/test_e2e_data.py
+++ b/azure-kusto-data/tests/test_e2e_data.py
@@ -22,6 +22,11 @@ from azure.kusto.data.exceptions import KustoServiceError
 from azure.kusto.data.kusto_trusted_endpoints import MatchRule, well_known_kusto_endpoints
 from azure.kusto.data.streaming_response import FrameType
 
+@pytest.fixture(scope="module")
+def event_loop_policy(request):
+    if platform.system() == "Windows":
+        return asyncio.WindowsSelectorEventLoopPolicy()
+    return asyncio.DefaultEventLoopPolicy()
 
 @pytest.fixture(params=["ManagedStreaming", "NormalClient"])
 def is_managed_streaming(request):
@@ -154,16 +159,6 @@ class TestE2E:
     def teardown_class(cls):
         with cls.get_client() as client:
             client.execute_mgmt(cls.test_db, ".drop table {}".format(cls.streaming_test_table))
-
-    @staticmethod
-    @pytest.fixture(scope="session")
-    def event_loop():
-        if platform.system() == "Windows":
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-        policy = asyncio.get_event_loop_policy()
-        loop = policy.new_event_loop()
-        yield loop
-        loop.close()
 
     @classmethod
     async def get_async_client(cls, app_insights=False) -> AsyncKustoClient:
@@ -333,6 +328,8 @@ class TestE2E:
             assert result.get_exceptions() == []
 
     def test_cloud_info(self):
+        if ".dev." in self.engine_cs:
+            pytest.skip("This test is not relevant for dev clusters")
         cloud_info = CloudSettings.get_cloud_info_for_cluster(self.engine_cs)
         assert cloud_info is not CloudSettings.DEFAULT_CLOUD
         assert cloud_info == CloudSettings.DEFAULT_CLOUD

--- a/azure-kusto-data/tests/test_e2e_data.py
+++ b/azure-kusto-data/tests/test_e2e_data.py
@@ -22,11 +22,13 @@ from azure.kusto.data.exceptions import KustoServiceError
 from azure.kusto.data.kusto_trusted_endpoints import MatchRule, well_known_kusto_endpoints
 from azure.kusto.data.streaming_response import FrameType
 
+
 @pytest.fixture(scope="module")
 def event_loop_policy(request):
     if platform.system() == "Windows":
         return asyncio.WindowsSelectorEventLoopPolicy()
     return asyncio.DefaultEventLoopPolicy()
+
 
 @pytest.fixture(params=["ManagedStreaming", "NormalClient"])
 def is_managed_streaming(request):

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -9,7 +9,7 @@ from azure.kusto.data import KustoConnectionStringBuilder, KustoClient
 local_emulator = False
 
 
-class KustoConnectionStringBuilderTests(unittest.TestCase):
+class KustoConnectionStringBuilderTests:
     """Tests class for KustoConnectionStringBuilder."""
 
     PASSWORDS_REPLACEMENT = "****"
@@ -311,7 +311,8 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
         finally:
             assert exception_occurred
 
-    def test_add_async_token_provider(self):
+    @pytest.mark.asyncio
+    async def test_add_async_token_provider(self):
         caller_token = "caller token"
 
         async def async_token_provider():
@@ -319,7 +320,7 @@ class KustoConnectionStringBuilderTests(unittest.TestCase):
 
         kscb = KustoConnectionStringBuilder.with_async_token_provider("localhost", async_token_provider)
 
-        assert kscb.async_token_provider() is not None
+        assert (await kscb.async_token_provider()) is not None
 
         exception_occurred = False
         try:

--- a/azure-kusto-data/tests/test_token_providers.py
+++ b/azure-kusto-data/tests/test_token_providers.py
@@ -352,9 +352,11 @@ class TokenProviderTests(unittest.TestCase):
 
     @staticmethod
     def test_azure_identity_default_token_provider():
-        app_id, app_key, auth_id = prepare_app_key_auth(optional=True)
-        if not app_id or not app_key or not auth_id:
+        auth = prepare_app_key_auth(optional=True)
+        if not auth:
             pytest.skip(" *** Skipped Azure Identity Provider Test ***")
+
+        app_id, app_key, auth_id = auth
 
         with AzureIdentityTokenCredentialProvider(KUSTO_URI, credential=DefaultAzureCredential()) as provider:
             token = provider.get_token()

--- a/azure-kusto-ingest/tests/test_e2e_ingest.py
+++ b/azure-kusto-ingest/tests/test_e2e_ingest.py
@@ -39,11 +39,13 @@ from azure.kusto.ingest import (
 def is_managed_streaming(request):
     return request.param == "ManagedStreaming"
 
+
 @pytest.fixture(scope="module")
 def event_loop_policy(request):
     if platform.system() == "Windows":
         return asyncio.WindowsSelectorEventLoopPolicy()
     return asyncio.DefaultEventLoopPolicy()
+
 
 class TestE2E:
     """A class to define mappings to deft table."""

--- a/azure-kusto-ingest/tests/test_e2e_ingest.py
+++ b/azure-kusto-ingest/tests/test_e2e_ingest.py
@@ -39,6 +39,11 @@ from azure.kusto.ingest import (
 def is_managed_streaming(request):
     return request.param == "ManagedStreaming"
 
+@pytest.fixture(scope="module")
+def event_loop_policy(request):
+    if platform.system() == "Windows":
+        return asyncio.WindowsSelectorEventLoopPolicy()
+    return asyncio.DefaultEventLoopPolicy()
 
 class TestE2E:
     """A class to define mappings to deft table."""
@@ -213,16 +218,6 @@ class TestE2E:
         cls.ingest_client.close()
         cls.streaming_ingest_client.close()
         cls.managed_streaming_ingest_client.close()
-
-    @staticmethod
-    @pytest.fixture(scope="session")
-    def event_loop():
-        if platform.system() == "Windows":
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-        policy = asyncio.get_event_loop_policy()
-        loop = policy.new_event_loop()
-        yield loop
-        loop.close()
 
     @classmethod
     async def get_async_client(cls) -> AsyncKustoClient:


### PR DESCRIPTION
- Fixed not correctly awaiting for async token providers to close
- Tests fixes:
  - Use new method for the event loop fixed, since the old one is deprecated
  - Fixed tests not being awaited correctly
  - Fixed exceptions if only some of the env vars are provided