### PR TITLE
Fix headers escaping and parsing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,8 @@ jobs:
           pip install pytest-cov --user
           pip install ./azure-kusto-data[aio,pandas] ./azure-kusto-ingest[aio,pandas] --user
           pip freeze
-      - uses: psf/black@stable
+      # We have to use an old version of this plugin, as the new one assumes python 3.8
+      - uses: psf/black@c8f1a5542c257491e1e093b1404481ece7f7e02c
         with:
           options: "--check --diff --line-length 160"
           version: "23.3.0"

--- a/azure-kusto-data/azure/kusto/data/client_details.py
+++ b/azure-kusto-data/azure/kusto/data/client_details.py
@@ -13,6 +13,7 @@ NONE = "NONE"
 REPLACE_REGEX = re.compile(r"[^a-zA-Z0-9_.\-()]")
 MAX_HEADER_LENGTH = 100
 
+
 @functools.lru_cache(maxsize=1)
 def default_script() -> str:
     """Returns the name of the script that is currently running"""

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -128,6 +128,7 @@ class KustoConnectionStringBuilder:
         https://kusto.azurewebsites.net/docs/concepts/kusto_connection_strings.html
         """
         assert_string_is_not_empty(connection_string)
+        self._client_details: Optional[ClientDetails] = None
         self._internal_dict = {}
         self._token_provider = None
         self._async_token_provider = None
@@ -644,7 +645,7 @@ class KustoConnectionStringBuilder:
 
     @property
     def client_details(self) -> ClientDetails:
-        return ClientDetails(self.application_for_tracing, self.user_name_for_tracing)
+        return self._client_details or ClientDetails(self.application_for_tracing, self.user_name_for_tracing)
 
     def _set_connector_details(
         self,
@@ -666,10 +667,7 @@ class KustoConnectionStringBuilder:
         :param app_version: The version of the containing application
         :param additional_fields: Additional fields to add to the header
         """
-        client_details = ClientDetails.set_connector_details(name, version, app_name, app_version, send_user, override_user, additional_fields)
-
-        self.application_for_tracing = client_details.application_for_tracing
-        self.user_name_for_tracing = client_details.user_name_for_tracing
+        self._client_details = ClientDetails.set_connector_details(name, version, app_name, app_version, send_user, override_user, additional_fields)
 
     def __str__(self) -> str:
         dict_copy = self._internal_dict.copy()

--- a/azure-kusto-data/tests/test_client_request_properties.py
+++ b/azure-kusto-data/tests/test_client_request_properties.py
@@ -229,9 +229,10 @@ def test_set_connector_escaped():
     assert params.request_headers["x-ms-user"] == "myUser"
     assert params.request_headers["x-ms-client-version"].startswith("Kusto.Python.Client:")
 
-    assert (params.request_headers["x-ms-app"] ==
-            "Kusto.Caf_:1_._0"
-            "|App.my_test____app:ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss|myField:myValue")
+    assert (
+        params.request_headers["x-ms-app"] == "Kusto.Caf_:1_._0"
+        "|App.my_test____app:ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss|myField:myValue"
+    )
 
 
 def test_kcsb_direct_escaped():


### PR DESCRIPTION
Changes the tracing format to be always allowed in headers, and easier to reason about:

- Only allowed chars: [a-zA-Z0-9_.\-()] (Note: not using \w because we don't want non-ascii chars)
 - Escape every part of the header, even when using set_connector_details 
- Remove the brackets around escaped fields, as they are not needed to parse anymore. So - Parsing is now simply splitting by |, and then you have pairs of key:value. 
- Limit the length of each field to 100 

So old: Kusto.Café:{1 . 0}|App.{Something}:{weird version} 
New: Kusto.Caf_:1_._0|App.Something:weird_versio