### PR TITLE
raise NotImplementedError if ignore_first_record is True

### DIFF
--- a/azure-kusto-ingest/azure/kusto/ingest/base_ingest_client.py
+++ b/azure-kusto-ingest/azure/kusto/ingest/base_ingest_client.py
@@ -83,6 +83,9 @@ class BaseIngestClient(metaclass=ABCMeta):
         """
         if self._is_closed:
             raise KustoClosedError()
+        
+        if ingestion_properties.ignore_first_record:
+            raise NotImplementedError("ignore_first_record not implemented for ingest_from_file")        
 
     @abstractmethod
     def ingest_from_stream(self, stream_descriptor: Union[StreamDescriptor, IO[AnyStr]], ingestion_properties: IngestionProperties) -> IngestionResult:


### PR DESCRIPTION
### Added
Added NotImplementedError if ignore_first_record is True to avoid introducing data integrity error when loading .csv file when invoking method ingest_from_file.  if ignore_first_record is set to True, then the header/first-row of the .csv file is ingested.  This change prevents the introduction of a data integrity error until this feature is implemented.  I tested change, but did not execute full regression.
