### PR TITLE
Fix json 401 error

### DIFF
--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -353,7 +353,7 @@ class KustoClient(_KustoClientBase):
         try:
             if 300 <= response.status_code < 400:
                 raise Exception("Unexpected redirection, got status code: " + str(response.status))
-            if response.content:
+            if response.text:
                 response_json = response.json()
             else:
                 raise KustoServiceError("The content of the response contains no data.", response)

--- a/azure-kusto-data/azure/kusto/data/client.py
+++ b/azure-kusto-data/azure/kusto/data/client.py
@@ -14,6 +14,7 @@ from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing import SpanKind
 
 from azure.kusto.data._telemetry import Span, MonitoredActivity
+from build.lib.azure.kusto.data.exceptions import KustoServiceError
 
 from .client_base import ExecuteRequestParams, _KustoClientBase
 from .client_request_properties import ClientRequestProperties
@@ -352,7 +353,10 @@ class KustoClient(_KustoClientBase):
         try:
             if 300 <= response.status_code < 400:
                 raise Exception("Unexpected redirection, got status code: " + str(response.status))
-            response_json = response.json()
+            if response.content:
+                response_json = response.json()
+            else:
+                raise KustoServiceError("The content of the response contains no data.", response)
             response.raise_for_status()
         except Exception as e:
             raise self._handle_http_error(e, endpoint, request.payload, response, response.status_code, response_json, response.text)

--- a/azure-kusto-data/azure/kusto/data/client_base.py
+++ b/azure-kusto-data/azure/kusto/data/client_base.py
@@ -109,7 +109,7 @@ class _KustoClientBase(abc.ABC):
             raise KustoThrottlingError("The request was throttled by the server.", response) from exception
 
         if status == 401:
-            raise PermissionError() from exception
+            raise KustoServiceError(f"401. Missing adequate access rights.", response) from exception
 
         if payload:
             message = f"An error occurred while trying to ingest: Status: {status}, Reason: {response.reason}, Text: {response_text}."

--- a/azure-kusto-data/azure/kusto/data/client_base.py
+++ b/azure-kusto-data/azure/kusto/data/client_base.py
@@ -108,6 +108,9 @@ class _KustoClientBase(abc.ABC):
         if status == 429:
             raise KustoThrottlingError("The request was throttled by the server.", response) from exception
 
+        if status == 401:
+            raise PermissionError() from exception
+
         if payload:
             message = f"An error occurred while trying to ingest: Status: {status}, Reason: {response.reason}, Text: {response_text}."
             if response_json:

--- a/azure-kusto-data/tests/kusto_client_common.py
+++ b/azure-kusto-data/tests/kusto_client_common.py
@@ -85,6 +85,8 @@ def mocked_requests_post(*args, **kwargs):
             file_name = "pandas_bool.json"
         elif "print dynamic" in kwargs["json"]["csl"]:
             file_name = "dynamic.json"
+        elif "execute_401" in kwargs["json"]["csl"]:
+            return MockResponse(None, 401, url)
         elif "take 0" in kwargs["json"]["csl"]:
             file_name = "zero_results.json"
         elif "PrimaryResultName" in kwargs["json"]["csl"]:

--- a/azure-kusto-data/tests/test_kusto_client.py
+++ b/azure-kusto-data/tests/test_kusto_client.py
@@ -127,6 +127,15 @@ class TestKustoClient(KustoClientTestsMixin):
             self._assert_dynamic_response(row)
 
     @patch("requests.Session.post", side_effect=mocked_requests_post)
+    def test_json_401(self, mock_post, method):
+        """Tests 401 permission errors."""
+        with KustoClient(self.HOST) as client:
+            with pytest.raises(PermissionError):
+                query = "execute_401"
+                response = method.__call__(client, "PythonTest", query)
+                get_response_first_primary_result(response)
+
+    @patch("requests.Session.post", side_effect=mocked_requests_post)
     def test_empty_result(self, mock_post, method):
         """Tests dynamic responses."""
         with KustoClient(self.HOST) as client:

--- a/azure-kusto-data/tests/test_kusto_client.py
+++ b/azure-kusto-data/tests/test_kusto_client.py
@@ -8,7 +8,7 @@ import pytest
 
 from azure.kusto.data import ClientRequestProperties, KustoClient, KustoConnectionStringBuilder
 from azure.kusto.data._cloud_settings import CloudSettings
-from azure.kusto.data.exceptions import KustoClosedError, KustoMultiApiError, KustoNetworkError
+from azure.kusto.data.exceptions import KustoClosedError, KustoMultiApiError, KustoNetworkError, KustoServiceError
 from azure.kusto.data.helpers import dataframe_from_result_table
 from azure.kusto.data.response import KustoStreamingResponseDataSet
 from tests.kusto_client_common import KustoClientTestsMixin, mocked_requests_post, get_response_first_primary_result, get_table_first_row, proxy_kcsb
@@ -130,7 +130,7 @@ class TestKustoClient(KustoClientTestsMixin):
     def test_json_401(self, mock_post, method):
         """Tests 401 permission errors."""
         with KustoClient(self.HOST) as client:
-            with pytest.raises(PermissionError):
+            with pytest.raises(KustoServiceError):
                 query = "execute_401"
                 response = method.__call__(client, "PythonTest", query)
                 get_response_first_primary_result(response)

--- a/azure-kusto-data/tests/test_kusto_client.py
+++ b/azure-kusto-data/tests/test_kusto_client.py
@@ -130,7 +130,7 @@ class TestKustoClient(KustoClientTestsMixin):
     def test_json_401(self, mock_post, method):
         """Tests 401 permission errors."""
         with KustoClient(self.HOST) as client:
-            with pytest.raises(KustoServiceError):
+            with pytest.raises(KustoServiceError, match=f"401. Missing adequate access rights."):
                 query = "execute_401"
                 response = method.__call__(client, "PythonTest", query)
                 get_response_first_primary_result(response)

--- a/azure-kusto-ingest/tests/test_e2e_ingest.py
+++ b/azure-kusto-ingest/tests/test_e2e_ingest.py
@@ -173,7 +173,7 @@ class TestE2E:
         cls.engine_cs = get_env("ENGINE_CONNECTION_STRING")
         cls.dm_cs = get_env("DM_CONNECTION_STRING", default=cls.engine_cs.replace("//", "//ingest-"))
 
-        #for JSON 401 test
+        # for JSON 401 test
         cls.dm_kcsb = KustoConnectionStringBuilder(cls.engine_cs)
 
         # Called to set the env variables for the default azure credentials
@@ -216,7 +216,6 @@ class TestE2E:
         # Clear the cache to guarantee that subsequent streaming ingestion requests incorporate database and table schema changes
         # See https://docs.microsoft.com/azure/data-explorer/kusto/management/data-ingestion/clear-schema-cache-command
         cls.client.execute(cls.test_db, ".clear database cache streamingingestion schema")
-
 
     @classmethod
     def teardown_class(cls):

--- a/azure-kusto-ingest/tests/test_e2e_ingest.py
+++ b/azure-kusto-ingest/tests/test_e2e_ingest.py
@@ -565,8 +565,3 @@ class TestE2E:
                 self.streaming_ingest_client.ingest_from_blob(blob_descriptor, ingestion_properties)
 
         await self.assert_rows_added(2, timeout=120)
-
-    def test_json_401(self):
-        with pytest.raises(KustoServiceError, match=f"401. Missing adequate access rights."):
-            self.dm_kcsb = KustoConnectionStringBuilder(self.engine_cs)
-            KustoClient(self.dm_kcsb).execute_mgmt(self.test_db, ".show version")

--- a/azure-kusto-ingest/tests/test_e2e_ingest.py
+++ b/azure-kusto-ingest/tests/test_e2e_ingest.py
@@ -173,9 +173,6 @@ class TestE2E:
         cls.engine_cs = get_env("ENGINE_CONNECTION_STRING")
         cls.dm_cs = get_env("DM_CONNECTION_STRING", default=cls.engine_cs.replace("//", "//ingest-"))
 
-        # for JSON 401 test
-        cls.dm_kcsb = KustoConnectionStringBuilder(cls.engine_cs)
-
         # Called to set the env variables for the default azure credentials
         prepare_app_key_auth(optional=True)
 

--- a/azure-kusto-ingest/tests/test_e2e_ingest.py
+++ b/azure-kusto-ingest/tests/test_e2e_ingest.py
@@ -567,9 +567,6 @@ class TestE2E:
         await self.assert_rows_added(2, timeout=120)
 
     def test_json_401(self):
-        try:
+        with pytest.raises(KustoServiceError):
             self.dm_kcsb = KustoConnectionStringBuilder(self.engine_cs)
             KustoClient(self.dm_kcsb).execute_mgmt(self.test_db, ".show version")
-            raise Exception("Should have failed")
-        except PermissionError:
-            pass

--- a/azure-kusto-ingest/tests/test_e2e_ingest.py
+++ b/azure-kusto-ingest/tests/test_e2e_ingest.py
@@ -567,6 +567,6 @@ class TestE2E:
         await self.assert_rows_added(2, timeout=120)
 
     def test_json_401(self):
-        with pytest.raises(KustoServiceError):
+        with pytest.raises(KustoServiceError, match=f"401. Missing adequate access rights."):
             self.dm_kcsb = KustoConnectionStringBuilder(self.engine_cs)
             KustoClient(self.dm_kcsb).execute_mgmt(self.test_db, ".show version")


### PR DESCRIPTION
1. Updated handle_http_error func to handle 401 errors. 
2. Updates client.py to check if json is empty before parsing.