### PR TITLE
Auth metadata endpoint is always rooted

### DIFF
--- a/azure-kusto-data/azure/kusto/data/_cloud_settings.py
+++ b/azure-kusto-data/azure/kusto/data/_cloud_settings.py
@@ -68,6 +68,7 @@ class CloudSettings:
         with cls._cloud_cache_lock:
             if kusto_uri in cls._cloud_cache:
                 return cls._cloud_cache[kusto_uri]
+            
             url_parts = urlparse(kusto_uri)
             url = f"{url_parts.scheme}://{url_parts.netloc}/{METADATA_ENDPOINT}"
 

--- a/azure-kusto-data/azure/kusto/data/_cloud_settings.py
+++ b/azure-kusto-data/azure/kusto/data/_cloud_settings.py
@@ -1,7 +1,7 @@
 import dataclasses
 from threading import Lock
 from typing import Optional, Dict
-from urllib.parse import urljoin
+from urllib.parse import urlparse
 
 import requests
 
@@ -68,7 +68,8 @@ class CloudSettings:
         with cls._cloud_cache_lock:
             if kusto_uri in cls._cloud_cache:
                 return cls._cloud_cache[kusto_uri]
-            url = urljoin(kusto_uri, METADATA_ENDPOINT)
+            url_parts = urlparse(kusto_uri)
+            url = f"{url_parts.scheme}://{url_parts.netloc}/{METADATA_ENDPOINT}"
 
             try:
                 # trace http get call for result

--- a/azure-kusto-data/azure/kusto/data/_cloud_settings.py
+++ b/azure-kusto-data/azure/kusto/data/_cloud_settings.py
@@ -68,7 +68,7 @@ class CloudSettings:
         with cls._cloud_cache_lock:
             if kusto_uri in cls._cloud_cache:
                 return cls._cloud_cache[kusto_uri]
-            
+
             url_parts = urlparse(kusto_uri)
             url = f"{url_parts.scheme}://{url_parts.netloc}/{METADATA_ENDPOINT}"
 

--- a/azure-kusto-data/tests/test_e2e_data.py
+++ b/azure-kusto-data/tests/test_e2e_data.py
@@ -10,6 +10,7 @@ import platform
 import random
 from datetime import datetime
 from typing import Optional, ClassVar, Callable
+from urllib.parse import urljoin
 
 import pytest
 from azure.identity import DefaultAzureCredential
@@ -336,7 +337,8 @@ class TestE2E:
         assert cloud_info is not CloudSettings.DEFAULT_CLOUD
         assert cloud_info == CloudSettings.DEFAULT_CLOUD
         assert cloud_info is CloudSettings.get_cloud_info_for_cluster(self.engine_cs)
-
+        assert cloud_info is CloudSettings.get_cloud_info_for_cluster(urljoin(self.engine_cs, "/test1/test2/test3"))
+        
     def test_cloud_info_404(self):
         pytest.skip("This test is currently wrong - until all cluster are updated to the redirect uri, this test will fail")
         cloud_info = CloudSettings.get_cloud_info_for_cluster("https://statusreturner.azurewebsites.net/404/test")

--- a/azure-kusto-data/tests/test_e2e_data.py
+++ b/azure-kusto-data/tests/test_e2e_data.py
@@ -345,6 +345,7 @@ class TestE2E:
 
     @pytest.mark.parametrize("code", [301, 302, 307, 308])
     def test_no_redirects_fail_in_cloud(self, code):
+        pytest.skip("This test is currently not supported as it relies on the URI path witch we now ignore")
         with KustoClient(
             KustoConnectionStringBuilder.with_azure_token_credential(f"https://statusreturner.azurewebsites.net/{code}/nocloud", self.__class__.cred())
         ) as client:
@@ -365,6 +366,7 @@ class TestE2E:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("code", [301, 302, 307, 308])
     async def test_no_redirects_fail_in_cloud_async(self, code):
+        pytest.skip("This test is currently not supported as it relies on the URI path witch we now ignore")
         async with AsyncKustoClient(
             KustoConnectionStringBuilder.with_azure_token_credential(f"https://statusreturner.azurewebsites.net/{code}/nocloud", self.__class__.async_cred())
         ) as client:

--- a/azure-kusto-data/tests/test_e2e_data.py
+++ b/azure-kusto-data/tests/test_e2e_data.py
@@ -337,8 +337,8 @@ class TestE2E:
         assert cloud_info is not CloudSettings.DEFAULT_CLOUD
         assert cloud_info == CloudSettings.DEFAULT_CLOUD
         assert cloud_info is CloudSettings.get_cloud_info_for_cluster(self.engine_cs)
-        assert cloud_info is CloudSettings.get_cloud_info_for_cluster(urljoin(self.engine_cs, "/test1/test2/test3"))
-        
+        assert cloud_info == CloudSettings.get_cloud_info_for_cluster(urljoin(self.engine_cs, "/test1/test2/test3"))
+
     def test_cloud_info_404(self):
         pytest.skip("This test is currently wrong - until all cluster are updated to the redirect uri, this test will fail")
         cloud_info = CloudSettings.get_cloud_info_for_cluster("https://statusreturner.azurewebsites.net/404/test")


### PR DESCRIPTION
### Changed
Auth metadata endpoint is always relative to the cluster URI
