### PR TITLE
KCSB alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- [BREAKING] Aligned the Connection String Builder keywords with the rest of the SDKs.
+This means that some keywords were removed, and they will no longer be parsed as part of the Connection String.  
+Building the Connection String using the builder method will still work as expected.  
+The following keywords have been removed:
+    - `msi_auth` / `msi_authentication`
+    - `msi_params` / `msi_type`
+    - `interactive_login`
+    - `az_cli`
+
 ### Fixed
 - Added `py.typed` markers
 

--- a/azure-kusto-data/MANIFEST.in
+++ b/azure-kusto-data/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.rst
 include azure/__init__.py
 include azure/kusto/data/wellKnownKustoEndpoints.json
+include azure/kusto/data/kcsb.json
 recursive-exclude tests *

--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -1,9 +1,7 @@
-import sys
+import json
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Union, Callable, Dict, Optional
-from functools import lru_cache
-import copy
-import json
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -17,6 +15,7 @@ def load_bundled_json(file_name: str) -> Dict:
     filename = Path(__file__).absolute().parent.joinpath(file_name)
     with filename.open("r", encoding="utf-8") as data:
         return json.load(data)
+
 
 @lru_cache(maxsize=1, typed=False)
 def default_dict() -> Converter:
@@ -49,10 +48,10 @@ def default_dict() -> Converter:
 
 
 def dataframe_from_result_table(
-    table: "Union[KustoResultTable, KustoStreamingResultTable]",
-    nullable_bools: bool = False,
-    converters_by_type: Optional[Converter] = None,
-    converters_by_column_name: Optional[Converter] = None,
+        table: "Union[KustoResultTable, KustoStreamingResultTable]",
+        nullable_bools: bool = False,
+        converters_by_type: Optional[Converter] = None,
+        converters_by_column_name: Optional[Converter] = None,
 ) -> "pd.DataFrame":
     f"""Converts Kusto tables into pandas DataFrame.
     :param azure.kusto.data._models.KustoResultTable table: Table received from the response.
@@ -106,7 +105,7 @@ def get_string_tail_lower_case(val, length):
     if length >= len(val):
         return val.lower()
 
-    return val[len(val) - length :].lower()
+    return val[len(val) - length:].lower()
 
 
 # TODO When moving to pandas 2 only - change to the appropriate type

--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -48,10 +48,10 @@ def default_dict() -> Converter:
 
 
 def dataframe_from_result_table(
-        table: "Union[KustoResultTable, KustoStreamingResultTable]",
-        nullable_bools: bool = False,
-        converters_by_type: Optional[Converter] = None,
-        converters_by_column_name: Optional[Converter] = None,
+    table: "Union[KustoResultTable, KustoStreamingResultTable]",
+    nullable_bools: bool = False,
+    converters_by_type: Optional[Converter] = None,
+    converters_by_column_name: Optional[Converter] = None,
 ) -> "pd.DataFrame":
     f"""Converts Kusto tables into pandas DataFrame.
     :param azure.kusto.data._models.KustoResultTable table: Table received from the response.
@@ -105,7 +105,7 @@ def get_string_tail_lower_case(val, length):
     if length >= len(val):
         return val.lower()
 
-    return val[len(val) - length:].lower()
+    return val[len(val) - length :].lower()
 
 
 # TODO When moving to pandas 2 only - change to the appropriate type

--- a/azure-kusto-data/azure/kusto/data/helpers.py
+++ b/azure-kusto-data/azure/kusto/data/helpers.py
@@ -1,7 +1,9 @@
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Union, Callable, Dict, Optional
 from functools import lru_cache
 import copy
+import json
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -10,6 +12,11 @@ if TYPE_CHECKING:
 # Alias for dataframe_from_result_table converter type
 Converter = Dict[str, Union[str, Callable[[str, "pd.DataFrame"], "pd.Series"]]]
 
+
+def load_bundled_json(file_name: str) -> Dict:
+    filename = Path(__file__).absolute().parent.joinpath(file_name)
+    with filename.open("r", encoding="utf-8") as data:
+        return json.load(data)
 
 @lru_cache(maxsize=1, typed=False)
 def default_dict() -> Converter:

--- a/azure-kusto-data/azure/kusto/data/kcsb.json
+++ b/azure-kusto-data/azure/kusto/data/kcsb.json
@@ -1,0 +1,221 @@
+{
+  "dstsfed": {
+    "aliases": [
+      "dstsfed",
+      "dstsfederatedsecurity",
+      "dststokentype"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "streaming": {
+    "aliases": [
+      "streaming"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "uncompressed": {
+    "aliases": [
+      "uncompressed"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "enforcemfa": {
+    "aliases": [
+      "enforcemfa"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "accept": {
+    "aliases": [
+      "accept"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "queryconsistency": {
+    "aliases": [
+      "queryconsistency"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "password": {
+    "aliases": [
+      "password",
+      "pwd"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "datasourceuri": {
+    "aliases": [
+      "datasourceuri",
+      "serveruri",
+      "clusteruri"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "azureregion": {
+    "aliases": [
+      "azureregion",
+      "region"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "namespace": {
+    "aliases": [
+      "namespace",
+      "ns"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "applicationcertificatethumbprint": {
+    "aliases": [
+      "applicationcertificatethumbprint",
+      "appcert"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "applicationcertificateissuerdistinguishedname": {
+    "aliases": [
+      "applicationcertificateissuerdistinguishedname",
+      "applicationcertificateissuer"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "applicationcertificatesubject": {
+    "aliases": [
+      "applicationcertificatesubject",
+      "applicationcertificatesubjectdistinguishedname"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "applicationtoken": {
+    "aliases": [
+      "applicationtoken",
+      "apptoken"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "usertoken": {
+    "aliases": [
+      "usertoken",
+      "usrtoken"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "applicationkey": {
+    "aliases": [
+      "applicationkey",
+      "appkey"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "applicationcertificateblob": {
+    "aliases": [
+      "applicationcertificateblob"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "applicationcertificatex5c": {
+    "aliases": [
+      "applicationcertificatex5c",
+      "applicationcertificatesendx5c",
+      "sendx5c",
+      "applicationcertificatesendpubliccertificate",
+      "sendcertificatechain"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "userid": {
+    "aliases": [
+      "userid",
+      "user",
+      "uid",
+      "loginhint",
+      "aaduserid"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "database": {
+    "aliases": [
+      "database",
+      "initialcatalog"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "federatedsecurity": {
+    "aliases": [
+      "federatedsecurity",
+      "aadfederatedsecurity",
+      "aadfed",
+      "fed",
+      "federated"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "tenantid": {
+    "aliases": [
+      "tenantid",
+      "tid",
+      "tenant",
+      "authority",
+      "domainhint"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "datasource": {
+    "aliases": [
+      "datasource",
+      "server",
+      "addr",
+      "address",
+      "networkaddress"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "traceappname": {
+    "aliases": [
+      "traceappname",
+      "applicationnamefortracing"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "traceusername": {
+    "aliases": [
+      "traceusername",
+      "usernamesfortracing"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "applicationclientid": {
+    "aliases": [
+      "applicationclientid",
+      "appclientid"
+    ],
+    "type": "string",
+    "secret": false
+  }
+}

--- a/azure-kusto-data/azure/kusto/data/kcsb.json
+++ b/azure-kusto-data/azure/kusto/data/kcsb.json
@@ -1,189 +1,5 @@
 {
-  "dstsfed": {
-    "aliases": [
-      "dstsfed",
-      "dstsfederatedsecurity",
-      "dststokentype"
-    ],
-    "type": "bool",
-    "secret": false
-  },
-  "streaming": {
-    "aliases": [
-      "streaming"
-    ],
-    "type": "bool",
-    "secret": false
-  },
-  "uncompressed": {
-    "aliases": [
-      "uncompressed"
-    ],
-    "type": "bool",
-    "secret": false
-  },
-  "enforcemfa": {
-    "aliases": [
-      "enforcemfa"
-    ],
-    "type": "bool",
-    "secret": false
-  },
-  "accept": {
-    "aliases": [
-      "accept"
-    ],
-    "type": "bool",
-    "secret": false
-  },
-  "queryconsistency": {
-    "aliases": [
-      "queryconsistency"
-    ],
-    "type": "bool",
-    "secret": false
-  },
-  "password": {
-    "aliases": [
-      "password",
-      "pwd"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "datasourceuri": {
-    "aliases": [
-      "datasourceuri",
-      "serveruri",
-      "clusteruri"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "azureregion": {
-    "aliases": [
-      "azureregion",
-      "region"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "namespace": {
-    "aliases": [
-      "namespace",
-      "ns"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "applicationcertificatethumbprint": {
-    "aliases": [
-      "applicationcertificatethumbprint",
-      "appcert"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "applicationcertificateissuerdistinguishedname": {
-    "aliases": [
-      "applicationcertificateissuerdistinguishedname",
-      "applicationcertificateissuer"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "applicationcertificatesubject": {
-    "aliases": [
-      "applicationcertificatesubject",
-      "applicationcertificatesubjectdistinguishedname"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "applicationtoken": {
-    "aliases": [
-      "applicationtoken",
-      "apptoken"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "usertoken": {
-    "aliases": [
-      "usertoken",
-      "usrtoken"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "applicationkey": {
-    "aliases": [
-      "applicationkey",
-      "appkey"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "applicationcertificateblob": {
-    "aliases": [
-      "applicationcertificateblob"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "applicationcertificatex5c": {
-    "aliases": [
-      "applicationcertificatex5c",
-      "applicationcertificatesendx5c",
-      "sendx5c",
-      "applicationcertificatesendpubliccertificate",
-      "sendcertificatechain"
-    ],
-    "type": "bool",
-    "secret": false
-  },
-  "userid": {
-    "aliases": [
-      "userid",
-      "user",
-      "uid",
-      "loginhint",
-      "aaduserid"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "database": {
-    "aliases": [
-      "database",
-      "initialcatalog"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "federatedsecurity": {
-    "aliases": [
-      "federatedsecurity",
-      "aadfederatedsecurity",
-      "aadfed",
-      "fed",
-      "federated"
-    ],
-    "type": "bool",
-    "secret": false
-  },
-  "tenantid": {
-    "aliases": [
-      "tenantid",
-      "tid",
-      "tenant",
-      "authority",
-      "domainhint"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "datasource": {
+  "Data Source": {
     "aliases": [
       "datasource",
       "server",
@@ -194,7 +10,192 @@
     "type": "string",
     "secret": false
   },
-  "traceappname": {
+  "dSTS Federated Security": {
+    "aliases": [
+      "dstsfed",
+      "dstsfederatedsecurity",
+      "dststokentype"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "Streaming": {
+    "aliases": [
+      "streaming"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "Uncompressed": {
+    "aliases": [
+      "uncompressed"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "EnforceMfa": {
+    "aliases": [
+      "enforcemfa"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "Accept": {
+    "aliases": [
+      "accept"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "Query Consistency": {
+    "aliases": [
+      "queryconsistency"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "Password": {
+    "aliases": [
+      "password",
+      "pwd"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "Data Source Uri": {
+    "aliases": [
+      "datasourceuri",
+      "serveruri",
+      "clusteruri"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "Azure Region": {
+    "aliases": [
+      "azureregion",
+      "region"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "Namespace": {
+    "aliases": [
+      "namespace",
+      "ns"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "Application Certificate Thumbprint": {
+    "aliases": [
+      "applicationcertificatethumbprint",
+      "appcert"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "Application Certificate Issuer Distinguished Name": {
+    "aliases": [
+      "applicationcertificateissuerdistinguishedname",
+      "applicationcertificateissuer"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "Application Certificate Subject Distinguished Name": {
+    "aliases": [
+      "applicationcertificatesubject",
+      "applicationcertificatesubjectdistinguishedname"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "Application Token": {
+    "aliases": [
+      "applicationtoken",
+      "apptoken"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "User Token": {
+    "aliases": [
+      "usertoken",
+      "usrtoken"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "Application Key": {
+    "aliases": [
+      "applicationkey",
+      "appkey"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "Application Certificate Blob": {
+    "aliases": [
+      "applicationcertificateblob"
+    ],
+    "type": "string",
+    "secret": true
+  },
+  "Application Certificate SendX5c": {
+    "aliases": [
+      "applicationcertificatex5c",
+      "applicationcertificatesendx5c",
+      "sendx5c",
+      "applicationcertificatesendpubliccertificate",
+      "sendcertificatechain"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "User ID": {
+    "aliases": [
+      "userid",
+      "user",
+      "uid",
+      "loginhint",
+      "aaduserid"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "Initial Catalog": {
+    "aliases": [
+      "database",
+      "initialcatalog"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "AAD Federated Security": {
+    "aliases": [
+      "federatedsecurity",
+      "aadfederatedsecurity",
+      "aadfed",
+      "fed",
+      "federated"
+    ],
+    "type": "bool",
+    "secret": false
+  },
+  "Authority Id": {
+    "aliases": [
+      "tenantid",
+      "tid",
+      "tenant",
+      "authority",
+      "authorityid",
+      "domainhint"
+    ],
+    "type": "string",
+    "secret": false
+  },
+  "Application Name for Tracing": {
     "aliases": [
       "traceappname",
       "applicationnamefortracing"
@@ -202,7 +203,7 @@
     "type": "string",
     "secret": false
   },
-  "traceusername": {
+  "User Name for Tracing": {
     "aliases": [
       "traceusername",
       "usernamesfortracing"
@@ -210,7 +211,7 @@
     "type": "string",
     "secret": false
   },
-  "applicationclientid": {
+  "Application Client Id": {
     "aliases": [
       "applicationclientid",
       "appclientid"

--- a/azure-kusto-data/azure/kusto/data/kcsb.json
+++ b/azure-kusto-data/azure/kusto/data/kcsb.json
@@ -93,7 +93,7 @@
       "appcert"
     ],
     "type": "string",
-    "secret": true
+    "secret": false
   },
   "Application Certificate Issuer Distinguished Name": {
     "aliases": [
@@ -101,7 +101,7 @@
       "applicationcertificateissuer"
     ],
     "type": "string",
-    "secret": true
+    "secret": false
   },
   "Application Certificate Subject Distinguished Name": {
     "aliases": [
@@ -109,7 +109,7 @@
       "applicationcertificatesubjectdistinguishedname"
     ],
     "type": "string",
-    "secret": true
+    "secret": false
   },
   "Application Token": {
     "aliases": [

--- a/azure-kusto-data/azure/kusto/data/kcsb.json
+++ b/azure-kusto-data/azure/kusto/data/kcsb.json
@@ -1,7 +1,6 @@
 {
   "Data Source": {
     "aliases": [
-      "datasource",
       "server",
       "addr",
       "address",
@@ -13,50 +12,38 @@
   "dSTS Federated Security": {
     "aliases": [
       "dstsfed",
-      "dstsfederatedsecurity",
       "dststokentype"
     ],
     "type": "bool",
     "secret": false
   },
   "Streaming": {
-    "aliases": [
-      "streaming"
-    ],
+    "aliases": [],
     "type": "bool",
     "secret": false
   },
   "Uncompressed": {
-    "aliases": [
-      "uncompressed"
-    ],
+    "aliases": [],
     "type": "bool",
     "secret": false
   },
   "EnforceMfa": {
-    "aliases": [
-      "enforcemfa"
-    ],
+    "aliases": [],
     "type": "bool",
     "secret": false
   },
   "Accept": {
-    "aliases": [
-      "accept"
-    ],
+    "aliases": [],
     "type": "bool",
     "secret": false
   },
   "Query Consistency": {
-    "aliases": [
-      "queryconsistency"
-    ],
+    "aliases": [],
     "type": "bool",
     "secret": false
   },
   "Password": {
     "aliases": [
-      "password",
       "pwd"
     ],
     "type": "string",
@@ -64,7 +51,6 @@
   },
   "Data Source Uri": {
     "aliases": [
-      "datasourceuri",
       "serveruri",
       "clusteruri"
     ],
@@ -73,7 +59,6 @@
   },
   "Azure Region": {
     "aliases": [
-      "azureregion",
       "region"
     ],
     "type": "string",
@@ -81,7 +66,6 @@
   },
   "Namespace": {
     "aliases": [
-      "namespace",
       "ns"
     ],
     "type": "string",
@@ -89,31 +73,27 @@
   },
   "Application Certificate Thumbprint": {
     "aliases": [
-      "applicationcertificatethumbprint",
       "appcert"
     ],
     "type": "string",
-    "secret": false
+    "secret": true
   },
   "Application Certificate Issuer Distinguished Name": {
     "aliases": [
-      "applicationcertificateissuerdistinguishedname",
       "applicationcertificateissuer"
     ],
     "type": "string",
-    "secret": false
+    "secret": true
   },
   "Application Certificate Subject Distinguished Name": {
     "aliases": [
-      "applicationcertificatesubject",
-      "applicationcertificatesubjectdistinguishedname"
+      "applicationcertificatesubject"
     ],
     "type": "string",
-    "secret": false
+    "secret": true
   },
   "Application Token": {
     "aliases": [
-      "applicationtoken",
       "apptoken"
     ],
     "type": "string",
@@ -121,7 +101,6 @@
   },
   "User Token": {
     "aliases": [
-      "usertoken",
       "usrtoken"
     ],
     "type": "string",
@@ -129,23 +108,19 @@
   },
   "Application Key": {
     "aliases": [
-      "applicationkey",
       "appkey"
     ],
     "type": "string",
     "secret": true
   },
   "Application Certificate Blob": {
-    "aliases": [
-      "applicationcertificateblob"
-    ],
+    "aliases": [],
     "type": "string",
     "secret": true
   },
   "Application Certificate SendX5c": {
     "aliases": [
       "applicationcertificatex5c",
-      "applicationcertificatesendx5c",
       "sendx5c",
       "applicationcertificatesendpubliccertificate",
       "sendcertificatechain"
@@ -155,7 +130,6 @@
   },
   "User ID": {
     "aliases": [
-      "userid",
       "user",
       "uid",
       "loginhint",
@@ -166,8 +140,7 @@
   },
   "Initial Catalog": {
     "aliases": [
-      "database",
-      "initialcatalog"
+      "database"
     ],
     "type": "string",
     "secret": false
@@ -175,7 +148,6 @@
   "AAD Federated Security": {
     "aliases": [
       "federatedsecurity",
-      "aadfederatedsecurity",
       "aadfed",
       "fed",
       "federated"
@@ -189,7 +161,6 @@
       "tid",
       "tenant",
       "authority",
-      "authorityid",
       "domainhint"
     ],
     "type": "string",
@@ -197,23 +168,20 @@
   },
   "Application Name for Tracing": {
     "aliases": [
-      "traceappname",
-      "applicationnamefortracing"
+      "traceappname"
     ],
     "type": "string",
     "secret": false
   },
   "User Name for Tracing": {
     "aliases": [
-      "traceusername",
-      "usernamesfortracing"
+      "traceusername"
     ],
     "type": "string",
     "secret": false
   },
   "Application Client Id": {
     "aliases": [
-      "applicationclientid",
       "appclientid"
     ],
     "type": "string",

--- a/azure-kusto-data/azure/kusto/data/kcsb.json
+++ b/azure-kusto-data/azure/kusto/data/kcsb.json
@@ -1,190 +1,218 @@
 {
-  "Data Source": {
-    "aliases": [
-      "server",
-      "addr",
-      "address",
-      "networkaddress"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "dSTS Federated Security": {
-    "aliases": [
-      "dstsfed",
-      "dststokentype"
-    ],
-    "type": "bool",
-    "secret": false
-  },
-  "Streaming": {
-    "aliases": [],
-    "type": "bool",
-    "secret": false
-  },
-  "Uncompressed": {
-    "aliases": [],
-    "type": "bool",
-    "secret": false
-  },
-  "EnforceMfa": {
-    "aliases": [],
-    "type": "bool",
-    "secret": false
-  },
-  "Accept": {
-    "aliases": [],
-    "type": "bool",
-    "secret": false
-  },
-  "Query Consistency": {
-    "aliases": [],
-    "type": "bool",
-    "secret": false
-  },
-  "Password": {
-    "aliases": [
-      "pwd"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "Data Source Uri": {
-    "aliases": [
-      "serveruri",
-      "clusteruri"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "Azure Region": {
-    "aliases": [
-      "region"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "Namespace": {
-    "aliases": [
-      "ns"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "Application Certificate Thumbprint": {
-    "aliases": [
-      "appcert"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "Application Certificate Issuer Distinguished Name": {
-    "aliases": [
-      "applicationcertificateissuer"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "Application Certificate Subject Distinguished Name": {
-    "aliases": [
-      "applicationcertificatesubject"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "Application Token": {
-    "aliases": [
-      "apptoken"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "User Token": {
-    "aliases": [
-      "usrtoken"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "Application Key": {
-    "aliases": [
-      "appkey"
-    ],
-    "type": "string",
-    "secret": true
-  },
-  "Application Certificate Blob": {
-    "aliases": [],
-    "type": "string",
-    "secret": true
-  },
-  "Application Certificate SendX5c": {
-    "aliases": [
-      "applicationcertificatex5c",
-      "sendx5c",
-      "applicationcertificatesendpubliccertificate",
-      "sendcertificatechain"
-    ],
-    "type": "bool",
-    "secret": false
-  },
-  "User ID": {
-    "aliases": [
-      "user",
-      "uid",
-      "loginhint",
-      "aaduserid"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "Initial Catalog": {
-    "aliases": [
-      "database"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "AAD Federated Security": {
-    "aliases": [
-      "federatedsecurity",
-      "aadfed",
-      "fed",
-      "federated"
-    ],
-    "type": "bool",
-    "secret": false
-  },
-  "Authority Id": {
-    "aliases": [
-      "tenantid",
-      "tid",
-      "tenant",
-      "authority",
-      "domainhint"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "Application Name for Tracing": {
-    "aliases": [
-      "traceappname"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "User Name for Tracing": {
-    "aliases": [
-      "traceusername"
-    ],
-    "type": "string",
-    "secret": false
-  },
-  "Application Client Id": {
-    "aliases": [
-      "appclientid"
-    ],
-    "type": "string",
-    "secret": false
-  }
+  "keywords": [
+    {
+      "name": "Data Source",
+      "aliases": [
+        "server",
+        "addr",
+        "address",
+        "networkaddress"
+      ],
+      "type": "string",
+      "secret": false
+    },
+    {
+      "name": "dSTS Federated Security",
+      "aliases": [
+        "dstsfed",
+        "dststokentype"
+      ],
+      "type": "bool",
+      "secret": false
+    },
+    {
+      "name": "Streaming",
+      "aliases": [],
+      "type": "bool",
+      "secret": false
+    },
+    {
+      "name": "Uncompressed",
+      "aliases": [],
+      "type": "bool",
+      "secret": false
+    },
+    {
+      "name": "EnforceMfa",
+      "aliases": [],
+      "type": "bool",
+      "secret": false
+    },
+    {
+      "name": "Accept",
+      "aliases": [],
+      "type": "bool",
+      "secret": false
+    },
+    {
+      "name": "Query Consistency",
+      "aliases": [],
+      "type": "bool",
+      "secret": false
+    },
+    {
+      "name": "Password",
+      "aliases": [
+        "pwd"
+      ],
+      "type": "string",
+      "secret": true
+    },
+    {
+      "name": "Data Source Uri",
+      "aliases": [
+        "serveruri",
+        "clusteruri"
+      ],
+      "type": "string",
+      "secret": false
+    },
+    {
+      "name": "Azure Region",
+      "aliases": [
+        "region"
+      ],
+      "type": "string",
+      "secret": false
+    },
+    {
+      "name": "Namespace",
+      "aliases": [
+        "ns"
+      ],
+      "type": "string",
+      "secret": false
+    },
+    {
+      "name": "Application Certificate Thumbprint",
+      "aliases": [
+        "appcert"
+      ],
+      "type": "string",
+      "secret": true
+    },
+    {
+      "name": "Application Certificate Issuer Distinguished Name",
+      "aliases": [
+        "applicationcertificateissuer"
+      ],
+      "type": "string",
+      "secret": true
+    },
+    {
+      "name": "Application Certificate Subject Distinguished Name",
+      "aliases": [
+        "applicationcertificatesubject"
+      ],
+      "type": "string",
+      "secret": true
+    },
+    {
+      "name": "Application Token",
+      "aliases": [
+        "apptoken"
+      ],
+      "type": "string",
+      "secret": true
+    },
+    {
+      "name": "User Token",
+      "aliases": [
+        "usrtoken"
+      ],
+      "type": "string",
+      "secret": true
+    },
+    {
+      "name": "Application Key",
+      "aliases": [
+        "appkey"
+      ],
+      "type": "string",
+      "secret": true
+    },
+    {
+      "name": "Application Certificate Blob",
+      "aliases": [],
+      "type": "string",
+      "secret": true
+    },
+    {
+      "name": "Application Certificate SendX5c",
+      "aliases": [
+        "applicationcertificatex5c",
+        "sendx5c",
+        "applicationcertificatesendpubliccertificate",
+        "sendcertificatechain"
+      ],
+      "type": "bool",
+      "secret": false
+    },
+    {
+      "name": "User ID",
+      "aliases": [
+        "user",
+        "uid",
+        "loginhint",
+        "aaduserid"
+      ],
+      "type": "string",
+      "secret": false
+    },
+    {
+      "name": "Initial Catalog",
+      "aliases": [
+        "database"
+      ],
+      "type": "string",
+      "secret": false
+    },
+    {
+      "name": "AAD Federated Security",
+      "aliases": [
+        "federatedsecurity",
+        "aadfed",
+        "fed",
+        "federated"
+      ],
+      "type": "bool",
+      "secret": false
+    },
+    {
+      "name": "Authority Id",
+      "aliases": [
+        "tenantid",
+        "tid",
+        "tenant",
+        "authority",
+        "domainhint"
+      ],
+      "type": "string",
+      "secret": false
+    },
+    {
+      "name": "Application Name for Tracing",
+      "aliases": [
+        "traceappname"
+      ],
+      "type": "string",
+      "secret": false
+    },
+    {
+      "name": "User Name for Tracing",
+      "aliases": [
+        "traceusername"
+      ],
+      "type": "string",
+      "secret": false
+    },
+    {
+      "name": "Application Client Id",
+      "aliases": [
+        "appclientid"
+      ],
+      "type": "string",
+      "secret": false
+    }
+  ]
 }

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -49,9 +49,9 @@ class InvalidKeywords(Enum):
 
 @dataclasses.dataclass(frozen=True)
 class Keyword:
-    _valid_keywords : ClassVar[List[str]] = [k.value for k in ValidKeywords]
-    _invalid_keywords : ClassVar[List[str]] = [k.value for k in InvalidKeywords]
-    _lookup : ClassVar[dict]
+    _valid_keywords: ClassVar[List[str]] = [k.value for k in ValidKeywords]
+    _invalid_keywords: ClassVar[List[str]] = [k.value for k in InvalidKeywords]
+    _lookup: ClassVar[dict]
 
     name: ValidKeywords
     type: str

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -148,7 +148,7 @@ class KustoConnectionStringBuilder:
 
     @classmethod
     def with_aad_user_password_authentication(
-            cls, connection_string: str, user_id: str, password: str, authority_id: str = "organizations"
+        cls, connection_string: str, user_id: str, password: str, authority_id: str = "organizations"
     ) -> "KustoConnectionStringBuilder":
         """
         Creates a KustoConnection string builder that will authenticate with AAD user name and
@@ -189,7 +189,7 @@ class KustoConnectionStringBuilder:
 
     @classmethod
     def with_aad_application_key_authentication(
-            cls, connection_string: str, aad_app_id: str, app_key: str, authority_id: str
+        cls, connection_string: str, aad_app_id: str, app_key: str, authority_id: str
     ) -> "KustoConnectionStringBuilder":
         """
         Creates a KustoConnection string builder that will authenticate with AAD application and key.
@@ -212,7 +212,7 @@ class KustoConnectionStringBuilder:
 
     @classmethod
     def with_aad_application_certificate_authentication(
-            cls, connection_string: str, aad_app_id: str, certificate: str, thumbprint: str, authority_id: str
+        cls, connection_string: str, aad_app_id: str, certificate: str, thumbprint: str, authority_id: str
     ) -> "KustoConnectionStringBuilder":
         """
         Creates a KustoConnection string builder that will authenticate with AAD application using
@@ -240,7 +240,7 @@ class KustoConnectionStringBuilder:
 
     @classmethod
     def with_aad_application_certificate_sni_authentication(
-            cls, connection_string: str, aad_app_id: str, private_certificate: str, public_certificate: str, thumbprint: str, authority_id: str
+        cls, connection_string: str, aad_app_id: str, private_certificate: str, public_certificate: str, thumbprint: str, authority_id: str
     ) -> "KustoConnectionStringBuilder":
         """
         Creates a KustoConnection string builder that will authenticate with AAD application using
@@ -287,7 +287,7 @@ class KustoConnectionStringBuilder:
 
     @classmethod
     def with_aad_device_authentication(
-            cls, connection_string: str, authority_id: str = "organizations", callback: DeviceCallbackType = None
+        cls, connection_string: str, authority_id: str = "organizations", callback: DeviceCallbackType = None
     ) -> "KustoConnectionStringBuilder":
         """
         Creates a KustoConnection string builder that will authenticate with AAD application and
@@ -322,7 +322,7 @@ class KustoConnectionStringBuilder:
 
     @classmethod
     def with_aad_managed_service_identity_authentication(
-            cls, connection_string: str, client_id: str = None, object_id: str = None, msi_res_id: str = None, timeout: int = None
+        cls, connection_string: str, client_id: str = None, object_id: str = None, msi_res_id: str = None, timeout: int = None
     ) -> "KustoConnectionStringBuilder":
         """
         Creates a KustoConnection string builder that will authenticate with AAD application, using
@@ -390,9 +390,9 @@ class KustoConnectionStringBuilder:
 
     @classmethod
     def with_async_token_provider(
-            cls,
-            connection_string: str,
-            async_token_provider: Callable[[], Coroutine[None, None, str]],
+        cls,
+        connection_string: str,
+        async_token_provider: Callable[[], Coroutine[None, None, str]],
     ) -> "KustoConnectionStringBuilder":
         """
         Create a KustoConnectionStringBuilder that uses an async callback function to obtain a connection token
@@ -410,7 +410,7 @@ class KustoConnectionStringBuilder:
 
     @classmethod
     def with_interactive_login(
-            cls, connection_string: str, user_id_hint: Optional[str] = None, tenant_hint: Optional[str] = None
+        cls, connection_string: str, user_id_hint: Optional[str] = None, tenant_hint: Optional[str] = None
     ) -> "KustoConnectionStringBuilder":
         kcsb = cls(connection_string)
         kcsb.interactive_login = True
@@ -425,10 +425,10 @@ class KustoConnectionStringBuilder:
 
     @classmethod
     def with_azure_token_credential(
-            cls,
-            connection_string: str,
-            credential: Optional[Any] = None,
-            credential_from_login_endpoint: Optional[Callable[[str], Any]] = None,
+        cls,
+        connection_string: str,
+        credential: Optional[Any] = None,
+        credential_from_login_endpoint: Optional[Callable[[str], Any]] = None,
     ) -> "KustoConnectionStringBuilder":
         """
         Create a KustoConnectionStringBuilder that uses an azure token credential to obtain a connection token.
@@ -548,14 +548,14 @@ class KustoConnectionStringBuilder:
         return self._internal_dict.get(ValidKeywords.TENANT_ID)
 
     def _set_connector_details(
-            self,
-            name: str,
-            version: str,
-            app_name: Optional[str] = None,
-            app_version: Optional[str] = None,
-            send_user: bool = False,
-            override_user: Optional[str] = None,
-            additional_fields: Optional[List[Tuple[str, str]]] = None,
+        self,
+        name: str,
+        version: str,
+        app_name: Optional[str] = None,
+        app_version: Optional[str] = None,
+        send_user: bool = False,
+        override_user: Optional[str] = None,
+        additional_fields: Optional[List[Tuple[str, str]]] = None,
     ):
         """
         Sets the connector details for tracing purposes.

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -102,6 +102,7 @@ class Keyword:
 
         return lookup[normalized]
 
+
 lookup = Keyword.init_lookup()
 
 

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -8,6 +8,7 @@ from ._token_providers import DeviceCallbackType
 from .client_details import ClientDetails
 from .helpers import load_bundled_json
 
+
 @unique
 class ValidKeywords(Enum):
     DATA_SOURCE = "Data Source"
@@ -25,7 +26,9 @@ class ValidKeywords(Enum):
     TRACE_APP_NAME = "Trace App Name"
     TRACE_USER_NAME = "Trace User Name"
 
+
 valid_keywords = [k.value for k in ValidKeywords]
+
 
 @dataclasses.dataclass(frozen=True)
 class Keyword:
@@ -39,6 +42,7 @@ class Keyword:
 
     def is_bool_type(self) -> bool:
         return self.type == "bool"
+
 
 kcsb_json: dict = load_bundled_json("kcsb.json")
 keywords = []
@@ -54,6 +58,7 @@ for k, v in kcsb_json.items():
     else:
         unsupported_keywords.append(k)
         unsupported_keywords.extend(v["aliases"])
+
 
 def parse_keyword(key: Union[str, ValidKeywords]) -> "Keyword":
     if isinstance(key, ValidKeywords):

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -8,16 +8,6 @@ from ._token_providers import DeviceCallbackType
 from .client_details import ClientDetails
 from .helpers import load_bundled_json
 
-
-def init_keywords():
-    kcsb_json: dict = load_bundled_json("kcsb.json")
-    return [Keyword(k, v["aliases"], v["type"], v["secret"]) for k, v in kcsb_json.items()]
-
-
-keywords = init_keywords()
-lookup = {a: v for v in keywords for a in v.aliases}
-
-
 @dataclasses.dataclass
 class Keyword:
     name: str
@@ -26,10 +16,19 @@ class Keyword:
     secret: bool
 
     def is_str_type(self) -> bool:
-        return self.type == "str"
+        return self.type == "string"
 
     def is_bool_type(self) -> bool:
         return self.type == "bool"
+
+
+def init_keywords():
+    kcsb_json: dict = load_bundled_json("kcsb.json")
+    return [Keyword(k, v["aliases"], v["type"], v["secret"]) for k, v in kcsb_json.items()]
+
+
+keywords = init_keywords()
+lookup = {a: v for v in keywords for a in v.aliases}
 
 
 @unique

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -1,5 +1,5 @@
 import dataclasses
-from enum import unique, StrEnum
+from enum import unique, Enum
 from typing import Union, Callable, Coroutine, Optional, Tuple, List, Any
 from urllib.parse import urlparse
 
@@ -33,7 +33,7 @@ class Keyword:
 
 
 @unique
-class ValidKeywords(StrEnum):
+class ValidKeywords(Enum):
     APPLICATION_TOKEN = "applicationtoken"
     USER_TOKEN = "usertoken"
     APPLICATION_KEY = "applicationkey"

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -31,6 +31,7 @@ class Keyword:
     def is_bool_type(self) -> bool:
         return self.type == "bool"
 
+
 @unique
 class ValidKeywords(StrEnum):
     APPLICATION_TOKEN = "applicationtoken"
@@ -545,7 +546,6 @@ class KustoConnectionStringBuilder:
     @property
     def domain_hint(self) -> Optional[str]:
         return self._internal_dict.get(ValidKeywords.TENANT_ID)
-
 
     def _set_connector_details(
             self,

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -8,6 +8,7 @@ from ._token_providers import DeviceCallbackType
 from .client_details import ClientDetails
 from .helpers import load_bundled_json
 
+
 @dataclasses.dataclass
 class Keyword:
     name: str

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -94,8 +94,8 @@ class KustoConnectionStringBuilder:
     msi_authentication: bool = False
     msi_parameters: Optional[dict] = None
 
-    token_provider: Optional[Callable[[], str]]
-    async_token_provider: Optional[Callable[[], Coroutine[None, None, str]]]
+    token_provider: Optional[Callable[[], str]] = None
+    async_token_provider: Optional[Callable[[], Coroutine[None, None, str]]] = None
 
     application_for_tracing: Optional[str] = None
     user_name_for_tracing: Optional[str] = None

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -51,7 +51,7 @@ class InvalidKeywords(Enum):
 class Keyword:
     _valid_keywords: ClassVar[List[str]] = [k.value for k in ValidKeywords]
     _invalid_keywords: ClassVar[List[str]] = [k.value for k in InvalidKeywords]
-    _lookup: ClassVar[dict] = {}
+    _lookup: ClassVar[dict]
 
     name: ValidKeywords
     type: str
@@ -68,7 +68,7 @@ class Keyword:
         return key.lower().replace(" ", "").replace("_", "")
 
     @classmethod
-    def init_lookup(cls) -> dict:
+    def init_lookup(cls):
         kcsb_json: dict = load_bundled_json("kcsb.json")
         lookup = {}
         for k, v in kcsb_json.items():
@@ -84,7 +84,7 @@ class Keyword:
             for alias in v["aliases"]:
                 lookup[Keyword.normalize_string(alias)] = keyword
 
-        return lookup
+        cls._lookup = lookup
 
     @classmethod
     def parse(cls, key: Union[str, ValidKeywords]) -> "Keyword":
@@ -107,6 +107,8 @@ class Keyword:
             key = key.value
 
         return cls._lookup[Keyword.normalize_string(key)]
+
+Keyword.init_lookup()
 
 
 class KustoConnectionStringBuilder:

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -51,7 +51,7 @@ class InvalidKeywords(Enum):
 class Keyword:
     _valid_keywords: ClassVar[List[str]] = [k.value for k in ValidKeywords]
     _invalid_keywords: ClassVar[List[str]] = [k.value for k in InvalidKeywords]
-    _lookup: ClassVar[dict]
+    _lookup: ClassVar[dict] = {}
 
     name: ValidKeywords
     type: str

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -99,7 +99,7 @@ class Keyword:
             raise KeyError(f"Unknown keyword: `{key}`")
 
         if lookup[normalized] == UNSUPPORTED_KEYWORD:
-            raise KeyError(f"Unsupported keyword: `{key}`")
+            raise KeyError(f"Keyword `{key}` is not supported by this SDK")
 
         return lookup[normalized]
 

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -71,15 +71,16 @@ class Keyword:
     def init_lookup(cls):
         kcsb_json: dict = load_bundled_json("kcsb.json")
         lookup = {}
-        for k, v in kcsb_json.items():
-            if k in cls._valid_keywords:
-                keyword = Keyword(ValidKeywords(k), v["type"], v["secret"])
-            elif k in cls._invalid_keywords:
+        for v in kcsb_json["keywords"]:
+            name = v["name"]
+            if name in cls._valid_keywords:
+                keyword = Keyword(ValidKeywords(name), v["type"], v["secret"])
+            elif name in cls._invalid_keywords:
                 keyword = UNSUPPORTED_KEYWORD
             else:
-                raise KeyError(f"Unknown keyword: `{k}`")
+                raise KeyError(f"Unknown keyword: `{name}`")
 
-            lookup[Keyword.normalize_string(k)] = keyword
+            lookup[Keyword.normalize_string(name)] = keyword
 
             for alias in v["aliases"]:
                 lookup[Keyword.normalize_string(alias)] = keyword

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -39,7 +39,6 @@ class InvalidKeywords(Enum):
     ENFORCE_MFA = "EnforceMfa"
     ACCEPT = "Accept"
     QUERY_CONSISTENCY = "Query Consistency"
-    PASSWORD = "Password"
     DATA_SOURCE_URI = "Data Source Uri"
     AZURE_REGION = "Azure Region"
     NAMESPACE = "Namespace"

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -108,6 +108,7 @@ class Keyword:
 
         return cls._lookup[Keyword.normalize_string(key)]
 
+
 Keyword.init_lookup()
 
 

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -56,7 +56,6 @@ invalid_keywords = [k.value for k in InvalidKeywords]
 @dataclasses.dataclass(frozen=True)
 class Keyword:
     name: ValidKeywords
-    aliases: List[str]
     type: str
     secret: bool
 
@@ -72,7 +71,7 @@ class Keyword:
         lookup = {}
         for k, v in kcsb_json.items():
             if k in valid_keywords:
-                keyword = Keyword(ValidKeywords(k), v["aliases"], v["type"], v["secret"])
+                keyword = Keyword(ValidKeywords(k), v["type"], v["secret"])
             else:
                 keyword = UNSUPPORTED_KEYWORD
 
@@ -130,8 +129,8 @@ class KustoConnectionStringBuilder:
     application_for_tracing: Optional[str] = None
     user_name_for_tracing: Optional[str] = None
 
-    credential: Optional[Any] = None
-    credential_from_login_endpoint: Optional[Any] = None
+    azure_credential: Optional[Any] = None
+    azure_credential_from_login_endpoint: Optional[Any] = None
 
     application_public_certificate: Optional[str] = None
 
@@ -484,8 +483,8 @@ class KustoConnectionStringBuilder:
         kcsb = cls(connection_string)
         kcsb[ValidKeywords.FEDERATED_SECURITY] = True
         kcsb.token_credential_login = True
-        kcsb.credential = credential
-        kcsb.credential_from_login_endpoint = credential_from_login_endpoint
+        kcsb.azure_credential = credential
+        kcsb.azure_credential_from_login_endpoint = credential_from_login_endpoint
 
         return kcsb
 

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -72,15 +72,16 @@ class Keyword:
         for k, v in kcsb_json.items():
             if k in valid_keywords:
                 keyword = Keyword(ValidKeywords(k), v["type"], v["secret"])
-            else:
+            elif k in invalid_keywords:
                 keyword = UNSUPPORTED_KEYWORD
+            else:
+                raise KeyError(f"Unknown keyword: `{k}`")
 
             lookup[Keyword.normalize_string(k)] = keyword
 
             for alias in v["aliases"]:
                 lookup[Keyword.normalize_string(alias)] = keyword
-            else:
-                raise KeyError(f"Unknown keyword: `{k}`")
+
         return lookup
 
     @staticmethod

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -626,7 +626,7 @@ class KustoConnectionStringBuilder:
         dict_copy = self._internal_dict.copy()
         for key in dict_copy:
             if lookup[Keyword.normalize_string(key.value)].secret:
-                dict_copy[key.value] = "****"
+                dict_copy[key] = "****"
         return self._build_connection_string(dict_copy)
 
     def __repr__(self) -> str:

--- a/azure-kusto-data/azure/kusto/data/kcsb.py
+++ b/azure-kusto-data/azure/kusto/data/kcsb.py
@@ -625,8 +625,8 @@ class KustoConnectionStringBuilder:
     def __str__(self) -> str:
         dict_copy = self._internal_dict.copy()
         for key in dict_copy:
-            if lookup[key.value].secret:
-                dict_copy[key] = "****"
+            if lookup[Keyword.normalize_string(key.value)].secret:
+                dict_copy[key.value] = "****"
         return self._build_connection_string(dict_copy)
 
     def __repr__(self) -> str:

--- a/azure-kusto-data/azure/kusto/data/kusto_trusted_endpoints.py
+++ b/azure-kusto-data/azure/kusto/data/kusto_trusted_endpoints.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from azure.kusto.data.helpers import get_string_tail_lower_case
 from azure.kusto.data.security import _is_local_address
 from .exceptions import KustoClientInvalidConnectionStringException
+from .helpers import load_bundled_json
 
 
 class MatchRule:
@@ -101,7 +102,5 @@ class KustoTrustedEndpoints:
         self._override_matcher = matcher
 
 
-_filename = Path(__file__).absolute().parent.joinpath("wellKnownKustoEndpoints.json")
-with _filename.open("r", encoding="utf-8") as data:
-    _well_known_kusto_endpoints_data = json.load(data)
+_well_known_kusto_endpoints_data = load_bundled_json("wellKnownKustoEndpoints.json")
 well_known_kusto_endpoints = KustoTrustedEndpoints()

--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -61,18 +61,18 @@ class _AadHelper:
             self.token_provider = BasicTokenProvider(kcsb.user_token, is_async=is_async)
         elif kcsb.application_token:
             self.token_provider = BasicTokenProvider(kcsb.application_token, is_async=is_async)
-        elif kcsb.az_cli:
+        elif kcsb.az_cli_login:
             self.token_provider = AzCliTokenProvider(self.kusto_uri, is_async=is_async)
         elif kcsb.token_provider or kcsb.async_token_provider:
             self.token_provider = CallbackTokenProvider(token_callback=kcsb.token_provider, async_token_callback=kcsb.async_token_provider, is_async=is_async)
-        elif kcsb.is_token_credential_auth:
+        elif kcsb.token_credential_login:
             self.token_provider = AzureIdentityTokenCredentialProvider(
                 self.kusto_uri,
                 is_async=is_async,
                 credential=kcsb.credential,
                 credential_from_login_endpoint=kcsb.credential_from_login_endpoint,
             )
-        elif kcsb.is_device_login_auth:
+        elif kcsb.device_login:
             self.token_provider = DeviceLoginTokenProvider(self.kusto_uri, kcsb.authority_id, kcsb.device_callback, is_async=is_async)
         else:
             self.token_provider = InteractiveLoginTokenProvider(self.kusto_uri, kcsb.authority_id, kcsb.login_hint, kcsb.domain_hint, is_async=is_async)

--- a/azure-kusto-data/azure/kusto/data/security.py
+++ b/azure-kusto-data/azure/kusto/data/security.py
@@ -69,8 +69,8 @@ class _AadHelper:
             self.token_provider = AzureIdentityTokenCredentialProvider(
                 self.kusto_uri,
                 is_async=is_async,
-                credential=kcsb.credential,
-                credential_from_login_endpoint=kcsb.credential_from_login_endpoint,
+                credential=kcsb.azure_credential,
+                credential_from_login_endpoint=kcsb.azure_credential_from_login_endpoint,
             )
         elif kcsb.device_login:
             self.token_provider = DeviceLoginTokenProvider(self.kusto_uri, kcsb.authority_id, kcsb.device_callback, is_async=is_async)

--- a/azure-kusto-data/setup.py
+++ b/azure-kusto-data/setup.py
@@ -45,7 +45,7 @@ setup(
     namespace_packages=["azure"],
     keywords="kusto wrapper client library",
     packages=find_packages(exclude=["azure", "*tests*", "*tests.*"]),
-    package_data={"": ["wellKnownKustoEndpoints.json", "py.typed"]},
+    package_data={"": ["wellKnownKustoEndpoints.json", "py.typed", "kcsb.json"]},
     include_package_data=True,
     install_requires=["python-dateutil>=2.8.0", "requests>=2.13.0", "azure-identity>=1.5.0,<2", "msal>=1.9.0,<2", "ijson~=3.1", "azure-core>=1.11.0,<2"],
     extras_require={"pandas": ["pandas"], "aio": ["aiohttp>=3.8.0,<4", "asgiref>=3.2.3,<4"]},

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -67,10 +67,10 @@ class KustoConnectionStringBuilderTests:
             assert isinstance(e, ValueError)
 
         kcsb1 = KustoConnectionStringBuilder("server=localhost")
-        kcsb1[KustoConnectionStringBuilder.ValidKeywords.application_client_id] = uuid
-        kcsb1[KustoConnectionStringBuilder.ValidKeywords.application_key] = key
+        kcsb1[KustoConnectionStringBuilder.ValidKeywords.APPLICATION_CLIENT_ID] = uuid
+        kcsb1[KustoConnectionStringBuilder.ValidKeywords.APPLICATION_KEY] = key
         kcsb1[KustoConnectionStringBuilder.ValidKeywords.authority_id] = "microsoft.com"
-        kcsb1[KustoConnectionStringBuilder.ValidKeywords.aad_federated_security] = True
+        kcsb1[KustoConnectionStringBuilder.ValidKeywords.FEDERATED_SECURITY] = True
         kcsbs.append(kcsb1)
 
         kcsb2 = KustoConnectionStringBuilder("Server=localhost")
@@ -115,7 +115,7 @@ class KustoConnectionStringBuilderTests:
         kcsb1 = KustoConnectionStringBuilder("Server=localhost")
         kcsb1[KustoConnectionStringBuilder.ValidKeywords.aad_user_id] = user
         kcsb1[KustoConnectionStringBuilder.ValidKeywords.password] = password
-        kcsb1[KustoConnectionStringBuilder.ValidKeywords.aad_federated_security] = True
+        kcsb1[KustoConnectionStringBuilder.ValidKeywords.FEDERATED_SECURITY] = True
         kcsbs.append(kcsb1)
 
         kcsb2 = KustoConnectionStringBuilder("server=localhost")

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License
-import unittest
 from uuid import uuid4
 
 import pytest
+
 from azure.kusto.data import KustoConnectionStringBuilder, KustoClient
 
 local_emulator = False
@@ -67,10 +67,10 @@ class KustoConnectionStringBuilderTests:
             assert isinstance(e, ValueError)
 
         kcsb1 = KustoConnectionStringBuilder("server=localhost")
-        kcsb1[KustoConnectionStringBuilder.ValidKeywords.APPLICATION_CLIENT_ID] = uuid
-        kcsb1[KustoConnectionStringBuilder.ValidKeywords.APPLICATION_KEY] = key
-        kcsb1[KustoConnectionStringBuilder.ValidKeywords.authority_id] = "microsoft.com"
-        kcsb1[KustoConnectionStringBuilder.ValidKeywords.FEDERATED_SECURITY] = True
+        kcsb1[ValidKeywords.APPLICATION_CLIENT_ID] = uuid
+        kcsb1[ValidKeywords.APPLICATION_KEY] = key
+        kcsb1[ValidKeywords.authority_id] = "microsoft.com"
+        kcsb1[ValidKeywords.FEDERATED_SECURITY] = True
         kcsbs.append(kcsb1)
 
         kcsb2 = KustoConnectionStringBuilder("Server=localhost")
@@ -113,9 +113,9 @@ class KustoConnectionStringBuilderTests:
         ]
 
         kcsb1 = KustoConnectionStringBuilder("Server=localhost")
-        kcsb1[KustoConnectionStringBuilder.ValidKeywords.aad_user_id] = user
-        kcsb1[KustoConnectionStringBuilder.ValidKeywords.password] = password
-        kcsb1[KustoConnectionStringBuilder.ValidKeywords.FEDERATED_SECURITY] = True
+        kcsb1[ValidKeywords.aad_user_id] = user
+        kcsb1[ValidKeywords.password] = password
+        kcsb1[ValidKeywords.FEDERATED_SECURITY] = True
         kcsbs.append(kcsb1)
 
         kcsb2 = KustoConnectionStringBuilder("server=localhost")
@@ -196,13 +196,13 @@ class KustoConnectionStringBuilderTests:
         assert kcsb.user_token is None
         assert kcsb.authority_id == "organizations"
         assert (
-            repr(kcsb)
-            == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;Application Token=%s" % token
+                repr(kcsb)
+                == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;Application Token=%s" % token
         )
         assert (
-            str(kcsb)
-            == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;Application Token=%s"
-            % self.PASSWORDS_REPLACEMENT
+                str(kcsb)
+                == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;Application Token=%s"
+                % self.PASSWORDS_REPLACEMENT
         )
 
     def test_aad_user_token(self):
@@ -220,9 +220,9 @@ class KustoConnectionStringBuilderTests:
         assert kcsb.authority_id == "organizations"
         assert repr(kcsb) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;User Token=%s" % token
         assert (
-            str(kcsb)
-            == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;User Token=%s"
-            % self.PASSWORDS_REPLACEMENT
+                str(kcsb)
+                == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;User Token=%s"
+                % self.PASSWORDS_REPLACEMENT
         )
 
     def test_add_msi(self):

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -364,7 +364,6 @@ class TestKustoConnectionStringBuilder:
             KustoConnectionStringBuilder("Data Source=localhost;Initial Catalog=NetDefaultDB;Namespace=Test")
         assert "Keyword `Namespace` is not supported by this SDK" in str(e.value)
 
-
     def test_unknown_keyword(self):
         with pytest.raises(KeyError) as e:
             KustoConnectionStringBuilder("Data Source=localhost;Initial Catalog=NetDefaultDB;Bla=Test")

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -5,12 +5,11 @@ from uuid import uuid4
 import pytest
 
 from azure.kusto.data import KustoConnectionStringBuilder, KustoClient
-from azure.kusto.data.kcsb import ValidKeywords
 
 local_emulator = False
 
 
-class KustoConnectionStringBuilderTests:
+class TestKustoConnectionStringBuilder:
     """Tests class for KustoConnectionStringBuilder."""
 
     PASSWORDS_REPLACEMENT = "****"
@@ -67,19 +66,12 @@ class KustoConnectionStringBuilderTests:
             # make sure error is raised when authority_id i none
             assert isinstance(e, ValueError)
 
-        kcsb1 = KustoConnectionStringBuilder("server=localhost")
-        kcsb1[ValidKeywords.APPLICATION_CLIENT_ID] = uuid
-        kcsb1[ValidKeywords.APPLICATION_KEY] = key
-        kcsb1[ValidKeywords.authority_id] = "microsoft.com"
-        kcsb1[ValidKeywords.FEDERATED_SECURITY] = True
-        kcsbs.append(kcsb1)
-
-        kcsb2 = KustoConnectionStringBuilder("Server=localhost")
-        kcsb2["AppclientId"] = uuid
-        kcsb2["Application key"] = key
-        kcsb2["Authority Id"] = "microsoft.com"
-        kcsb2["aad federated security"] = True
-        kcsbs.append(kcsb2)
+        kcsb = KustoConnectionStringBuilder("Server=localhost")
+        kcsb["AppclientId"] = uuid
+        kcsb["Application key"] = key
+        kcsb["Authority Id"] = "microsoft.com"
+        kcsb["aad federated security"] = True
+        kcsbs.append(kcsb)
 
         for kcsb in kcsbs:
             assert kcsb.data_source == "localhost"
@@ -101,74 +93,69 @@ class KustoConnectionStringBuilderTests:
                 uuid, self.PASSWORDS_REPLACEMENT, "microsoft.com"
             )
 
-    def test_aad_user(self):
-        """Checks kcsb that is created with AAD user credentials."""
-        user = "test"
-        password = "Pa$$w0rd"
-        kcsbs = [
-            KustoConnectionStringBuilder("localhost;AAD User ID={0};password={1} ;AAD Federated Security=True ".format(user, password)),
-            KustoConnectionStringBuilder("Data Source=localhost ; AaD User ID={0}; Password ={1} ;AAD Federated Security=True".format(user, password)),
-            KustoConnectionStringBuilder(" Addr = localhost ; AAD User ID = {0} ; Pwd ={1} ;AAD Federated Security=True".format(user, password)),
-            KustoConnectionStringBuilder("Network Address = localhost; AAD User iD = {0} ; Pwd = {1} ;AAD Federated Security= True  ".format(user, password)),
-            KustoConnectionStringBuilder.with_aad_user_password_authentication("localhost", user, password),
-        ]
-
-        kcsb1 = KustoConnectionStringBuilder("Server=localhost")
-        kcsb1[ValidKeywords.aad_user_id] = user
-        kcsb1[ValidKeywords.password] = password
-        kcsb1[ValidKeywords.FEDERATED_SECURITY] = True
-        kcsbs.append(kcsb1)
-
-        kcsb2 = KustoConnectionStringBuilder("server=localhost")
-        kcsb2["AAD User ID"] = user
-        kcsb2["Password"] = password
-        kcsb2["aad federated security"] = True
-        kcsbs.append(kcsb2)
-
-        for kcsb in kcsbs:
-            assert kcsb.data_source == "localhost"
-            assert kcsb.aad_federated_security
-            assert kcsb.aad_user_id == user
-            assert kcsb.password == password
-            assert kcsb.application_client_id is None
-            assert kcsb.application_key is None
-            assert kcsb.authority_id == "organizations"
-            assert repr(
-                kcsb
-            ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=organizations".format(
-                user, password
-            )
-            assert str(
-                kcsb
-            ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=organizations".format(
-                user, self.PASSWORDS_REPLACEMENT
-            )
-
-    def test_aad_user_with_authority(self):
-        """Checks kcsb that is created with AAD user credentials."""
-        user = "test2"
-        password = "Pa$$w0rd2"
-        authority_id = "13456"
-
-        kcsb = KustoConnectionStringBuilder.with_aad_user_password_authentication("localhost", user, password, authority_id)
-
-        assert kcsb.data_source == "localhost"
-        assert kcsb.aad_federated_security
-        assert kcsb.aad_user_id == user
-        assert kcsb.password == password
-        assert kcsb.application_client_id is None
-        assert kcsb.application_key is None
-        assert kcsb.authority_id == authority_id
-        assert repr(
-            kcsb
-        ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=13456".format(
-            user, password
-        )
-        assert str(
-            kcsb
-        ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=13456".format(
-            user, self.PASSWORDS_REPLACEMENT
-        )
+    # TODO - decide what to do with these, depends on if we want to keep the password keyword
+    # def test_aad_user(self):
+    #     """Checks kcsb that is created with AAD user credentials."""
+    #     user = "test"
+    #     password = "Pa$$w0rd"
+    #     kcsbs = [
+    #         KustoConnectionStringBuilder("localhost;AAD User ID={0};password={1} ;AAD Federated Security=True ".format(user, password)),
+    #         KustoConnectionStringBuilder("Data Source=localhost ; AaD User ID={0}; Password ={1} ;AAD Federated Security=True".format(user, password)),
+    #         KustoConnectionStringBuilder(" Addr = localhost ; AAD User ID = {0} ; Pwd ={1} ;AAD Federated Security=True".format(user, password)),
+    #         KustoConnectionStringBuilder("Network Address = localhost; AAD User iD = {0} ; Pwd = {1} ;AAD Federated Security= True  ".format(user, password)),
+    #         KustoConnectionStringBuilder.with_aad_user_password_authentication("localhost", user, password),
+    #     ]
+    #
+    #     kcsb2 = KustoConnectionStringBuilder("server=localhost")
+    #     kcsb2["AAD User ID"] = user
+    #     kcsb2["Password"] = password
+    #     kcsb2["aad federated security"] = True
+    #     kcsbs.append(kcsb2)
+    #
+    #     for kcsb in kcsbs:
+    #         assert kcsb.data_source == "localhost"
+    #         assert kcsb.aad_federated_security
+    #         assert kcsb.aad_user_id == user
+    #         assert kcsb.password == password
+    #         assert kcsb.application_client_id is None
+    #         assert kcsb.application_key is None
+    #         assert kcsb.authority_id == "organizations"
+    #         assert repr(
+    #             kcsb
+    #         ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=organizations".format(
+    #             user, password
+    #         )
+    #         assert str(
+    #             kcsb
+    #         ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=organizations".format(
+    #             user, self.PASSWORDS_REPLACEMENT
+    #         )
+    #
+    # def test_aad_user_with_authority(self):
+    #     """Checks kcsb that is created with AAD user credentials."""
+    #     user = "test2"
+    #     password = "Pa$$w0rd2"
+    #     authority_id = "13456"
+    #
+    #     kcsb = KustoConnectionStringBuilder.with_aad_user_password_authentication("localhost", user, password, authority_id)
+    #
+    #     assert kcsb.data_source == "localhost"
+    #     assert kcsb.aad_federated_security
+    #     assert kcsb.aad_user_id == user
+    #     assert kcsb.password == password
+    #     assert kcsb.application_client_id is None
+    #     assert kcsb.application_key is None
+    #     assert kcsb.authority_id == authority_id
+    #     assert repr(
+    #         kcsb
+    #     ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=13456".format(
+    #         user, password
+    #     )
+    #     assert str(
+    #         kcsb
+    #     ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=13456".format(
+    #         user, self.PASSWORDS_REPLACEMENT
+    #     )
 
     def test_aad_device_login(self):
         """Checks kcsb that is created with AAD device login."""

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import pytest
 
 from azure.kusto.data import KustoConnectionStringBuilder, KustoClient
-from kusto.data.kcsb import ValidKeywords
+from azure.kusto.data.kcsb import ValidKeywords
 
 local_emulator = False
 

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 
 from azure.kusto.data import KustoConnectionStringBuilder, KustoClient
+from kusto.data.kcsb import ValidKeywords
 
 local_emulator = False
 

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -197,13 +197,13 @@ class KustoConnectionStringBuilderTests:
         assert kcsb.user_token is None
         assert kcsb.authority_id == "organizations"
         assert (
-                repr(kcsb)
-                == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;Application Token=%s" % token
+            repr(kcsb)
+            == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;Application Token=%s" % token
         )
         assert (
-                str(kcsb)
-                == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;Application Token=%s"
-                % self.PASSWORDS_REPLACEMENT
+            str(kcsb)
+            == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;Application Token=%s"
+            % self.PASSWORDS_REPLACEMENT
         )
 
     def test_aad_user_token(self):
@@ -221,9 +221,9 @@ class KustoConnectionStringBuilderTests:
         assert kcsb.authority_id == "organizations"
         assert repr(kcsb) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;User Token=%s" % token
         assert (
-                str(kcsb)
-                == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;User Token=%s"
-                % self.PASSWORDS_REPLACEMENT
+            str(kcsb)
+            == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;Authority Id=organizations;User Token=%s"
+            % self.PASSWORDS_REPLACEMENT
         )
 
     def test_add_msi(self):

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -362,7 +362,8 @@ class TestKustoConnectionStringBuilder:
     def test_unsupported_keyword(self):
         with pytest.raises(KeyError) as e:
             KustoConnectionStringBuilder("Data Source=localhost;Initial Catalog=NetDefaultDB;Namespace=Test")
-        assert "Keyword `Namespace` is not supported in this SDK" in str(e.value)
+        assert "Keyword `Namespace` is not supported by this SDK" in str(e.value)
+
 
     def test_unknown_keyword(self):
         with pytest.raises(KeyError) as e:

--- a/azure-kusto-data/tests/test_kusto_connection_string_builder.py
+++ b/azure-kusto-data/tests/test_kusto_connection_string_builder.py
@@ -93,69 +93,64 @@ class TestKustoConnectionStringBuilder:
                 uuid, self.PASSWORDS_REPLACEMENT, "microsoft.com"
             )
 
-    # TODO - decide what to do with these, depends on if we want to keep the password keyword
-    # def test_aad_user(self):
-    #     """Checks kcsb that is created with AAD user credentials."""
-    #     user = "test"
-    #     password = "Pa$$w0rd"
-    #     kcsbs = [
-    #         KustoConnectionStringBuilder("localhost;AAD User ID={0};password={1} ;AAD Federated Security=True ".format(user, password)),
-    #         KustoConnectionStringBuilder("Data Source=localhost ; AaD User ID={0}; Password ={1} ;AAD Federated Security=True".format(user, password)),
-    #         KustoConnectionStringBuilder(" Addr = localhost ; AAD User ID = {0} ; Pwd ={1} ;AAD Federated Security=True".format(user, password)),
-    #         KustoConnectionStringBuilder("Network Address = localhost; AAD User iD = {0} ; Pwd = {1} ;AAD Federated Security= True  ".format(user, password)),
-    #         KustoConnectionStringBuilder.with_aad_user_password_authentication("localhost", user, password),
-    #     ]
-    #
-    #     kcsb2 = KustoConnectionStringBuilder("server=localhost")
-    #     kcsb2["AAD User ID"] = user
-    #     kcsb2["Password"] = password
-    #     kcsb2["aad federated security"] = True
-    #     kcsbs.append(kcsb2)
-    #
-    #     for kcsb in kcsbs:
-    #         assert kcsb.data_source == "localhost"
-    #         assert kcsb.aad_federated_security
-    #         assert kcsb.aad_user_id == user
-    #         assert kcsb.password == password
-    #         assert kcsb.application_client_id is None
-    #         assert kcsb.application_key is None
-    #         assert kcsb.authority_id == "organizations"
-    #         assert repr(
-    #             kcsb
-    #         ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=organizations".format(
-    #             user, password
-    #         )
-    #         assert str(
-    #             kcsb
-    #         ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=organizations".format(
-    #             user, self.PASSWORDS_REPLACEMENT
-    #         )
-    #
-    # def test_aad_user_with_authority(self):
-    #     """Checks kcsb that is created with AAD user credentials."""
-    #     user = "test2"
-    #     password = "Pa$$w0rd2"
-    #     authority_id = "13456"
-    #
-    #     kcsb = KustoConnectionStringBuilder.with_aad_user_password_authentication("localhost", user, password, authority_id)
-    #
-    #     assert kcsb.data_source == "localhost"
-    #     assert kcsb.aad_federated_security
-    #     assert kcsb.aad_user_id == user
-    #     assert kcsb.password == password
-    #     assert kcsb.application_client_id is None
-    #     assert kcsb.application_key is None
-    #     assert kcsb.authority_id == authority_id
-    #     assert repr(
-    #         kcsb
-    #     ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=13456".format(
-    #         user, password
-    #     )
-    #     assert str(
-    #         kcsb
-    #     ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;AAD User ID={0};Password={1};Authority Id=13456".format(
-    #         user, self.PASSWORDS_REPLACEMENT
-    #     )
+    def test_aad_user(self):
+        """Checks kcsb that is created with AAD user credentials."""
+        user = "test"
+        password = "Pa$$w0rd"
+        kcsbs = [
+            KustoConnectionStringBuilder("localhost;User ID={0};password={1} ;AAD Federated Security=True ".format(user, password)),
+            KustoConnectionStringBuilder("Data Source=localhost ; AaD User ID={0}; Password ={1} ;AAD Federated Security=True".format(user, password)),
+            KustoConnectionStringBuilder(" Addr = localhost ; User ID = {0} ; Pwd ={1} ;AAD Federated Security=True".format(user, password)),
+            KustoConnectionStringBuilder("Network Address = localhost; AAD User iD = {0} ; Pwd = {1} ;AAD Federated Security= True  ".format(user, password)),
+            KustoConnectionStringBuilder.with_aad_user_password_authentication("localhost", user, password),
+        ]
+
+        kcsb2 = KustoConnectionStringBuilder("server=localhost")
+        kcsb2["User ID"] = user
+        kcsb2["Password"] = password
+        kcsb2["aad federated security"] = True
+        kcsbs.append(kcsb2)
+
+        for kcsb in kcsbs:
+            assert kcsb.data_source == "localhost"
+            assert kcsb.aad_federated_security
+            assert kcsb.aad_user_id == user
+            assert kcsb.password == password
+            assert kcsb.application_client_id is None
+            assert kcsb.application_key is None
+            assert kcsb.authority_id == "organizations"
+            assert repr(
+                kcsb
+            ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;User ID={0};Password={1};Authority Id=organizations".format(
+                user, password
+            )
+            assert str(
+                kcsb
+            ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;User ID={0};Password={1};Authority Id=organizations".format(
+                user, self.PASSWORDS_REPLACEMENT
+            )
+
+    def test_aad_user_with_authority(self):
+        """Checks kcsb that is created with AAD user credentials."""
+        user = "test2"
+        password = "Pa$$w0rd2"
+        authority_id = "13456"
+
+        kcsb = KustoConnectionStringBuilder.with_aad_user_password_authentication("localhost", user, password, authority_id)
+
+        assert kcsb.data_source == "localhost"
+        assert kcsb.aad_federated_security
+        assert kcsb.aad_user_id == user
+        assert kcsb.password == password
+        assert kcsb.application_client_id is None
+        assert kcsb.application_key is None
+        assert kcsb.authority_id == authority_id
+        assert repr(
+            kcsb
+        ) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;User ID={0};Password={1};Authority Id=13456".format(user, password)
+        assert str(kcsb) == "Data Source=localhost;Initial Catalog=NetDefaultDB;AAD Federated Security=True;User ID={0};Password={1};Authority Id=13456".format(
+            user, self.PASSWORDS_REPLACEMENT
+        )
 
     def test_aad_device_login(self):
         """Checks kcsb that is created with AAD device login."""
@@ -363,3 +358,13 @@ class TestKustoConnectionStringBuilder:
         client = KustoClient(kcsb)
         assert client._kusto_cluster == "https://help.kusto.windows.net/Test/Test2/"
         assert client.default_database == "NetDefaultDB"
+
+    def test_unsupported_keyword(self):
+        with pytest.raises(KeyError) as e:
+            KustoConnectionStringBuilder("Data Source=localhost;Initial Catalog=NetDefaultDB;Namespace=Test")
+        assert "Keyword `Namespace` is not supported in this SDK" in str(e.value)
+
+    def test_unknown_keyword(self):
+        with pytest.raises(KeyError) as e:
+            KustoConnectionStringBuilder("Data Source=localhost;Initial Catalog=NetDefaultDB;Bla=Test")
+        assert "Unknown keyword: `Bla`" in str(e.value)

--- a/azure-kusto-ingest/tests/test_e2e_ingest.py
+++ b/azure-kusto-ingest/tests/test_e2e_ingest.py
@@ -537,31 +537,31 @@ class TestE2E:
 
         await self.assert_rows_added(1, timeout=120)
 
-    @pytest.mark.asyncio
-    async def test_streaming_ingest_from_blob(self, is_managed_streaming):
-        ingestion_properties = IngestionProperties(
-            database=self.test_db,
-            table=self.test_table,
-            data_format=DataFormat.JSON,
-            ingestion_mapping_reference="JsonMapping",
-            ingestion_mapping_kind=IngestionMappingKind.JSON,
-        )
-        containers = self.ingest_client._resource_manager.get_containers()
-
-        with FileDescriptor(self.json_file_path).open(False) as stream:
-            blob_descriptor = self.ingest_client.upload_blob(
-                containers,
-                FileDescriptor(self.json_file_path),
-                ingestion_properties.database,
-                ingestion_properties.table,
-                stream,
-                None,
-                10 * 60,
-                3,
-            )
-            if is_managed_streaming:
-                self.managed_streaming_ingest_client.ingest_from_blob(blob_descriptor, ingestion_properties)
-            else:
-                self.streaming_ingest_client.ingest_from_blob(blob_descriptor, ingestion_properties)
-
-        await self.assert_rows_added(2, timeout=120)
+    # @pytest.mark.asyncio
+    # async def test_streaming_ingest_from_blob(self, is_managed_streaming):
+    #     ingestion_properties = IngestionProperties(
+    #         database=self.test_db,
+    #         table=self.test_table,
+    #         data_format=DataFormat.JSON,
+    #         ingestion_mapping_reference="JsonMapping",
+    #         ingestion_mapping_kind=IngestionMappingKind.JSON,
+    #     )
+    #     containers = self.ingest_client._resource_manager.get_containers()
+    #
+    #     with FileDescriptor(self.json_file_path).open(False) as stream:
+    #         blob_descriptor = self.ingest_client.upload_blob(
+    #             containers,
+    #             FileDescriptor(self.json_file_path),
+    #             ingestion_properties.database,
+    #             ingestion_properties.table,
+    #             stream,
+    #             None,
+    #             10 * 60,
+    #             3,
+    #         )
+    #         if is_managed_streaming:
+    #             self.managed_streaming_ingest_client.ingest_from_blob(blob_descriptor, ingestion_properties)
+    #         else:
+    #             self.streaming_ingest_client.ingest_from_blob(blob_descriptor, ingestion_properties)
+    #
+    #     await self.assert_rows_added(2, timeout=120)

--- a/azure-kusto-ingest/tests/test_e2e_ingest.py
+++ b/azure-kusto-ingest/tests/test_e2e_ingest.py
@@ -537,31 +537,31 @@ class TestE2E:
 
         await self.assert_rows_added(1, timeout=120)
 
-    # @pytest.mark.asyncio
-    # async def test_streaming_ingest_from_blob(self, is_managed_streaming):
-    #     ingestion_properties = IngestionProperties(
-    #         database=self.test_db,
-    #         table=self.test_table,
-    #         data_format=DataFormat.JSON,
-    #         ingestion_mapping_reference="JsonMapping",
-    #         ingestion_mapping_kind=IngestionMappingKind.JSON,
-    #     )
-    #     containers = self.ingest_client._resource_manager.get_containers()
-    #
-    #     with FileDescriptor(self.json_file_path).open(False) as stream:
-    #         blob_descriptor = self.ingest_client.upload_blob(
-    #             containers,
-    #             FileDescriptor(self.json_file_path),
-    #             ingestion_properties.database,
-    #             ingestion_properties.table,
-    #             stream,
-    #             None,
-    #             10 * 60,
-    #             3,
-    #         )
-    #         if is_managed_streaming:
-    #             self.managed_streaming_ingest_client.ingest_from_blob(blob_descriptor, ingestion_properties)
-    #         else:
-    #             self.streaming_ingest_client.ingest_from_blob(blob_descriptor, ingestion_properties)
-    #
-    #     await self.assert_rows_added(2, timeout=120)
+    @pytest.mark.asyncio
+    async def test_streaming_ingest_from_blob(self, is_managed_streaming):
+        ingestion_properties = IngestionProperties(
+            database=self.test_db,
+            table=self.test_table,
+            data_format=DataFormat.JSON,
+            ingestion_mapping_reference="JsonMapping",
+            ingestion_mapping_kind=IngestionMappingKind.JSON,
+        )
+        containers = self.ingest_client._resource_manager.get_containers()
+
+        with FileDescriptor(self.json_file_path).open(False) as stream:
+            blob_descriptor = self.ingest_client.upload_blob(
+                containers,
+                FileDescriptor(self.json_file_path),
+                ingestion_properties.database,
+                ingestion_properties.table,
+                stream,
+                None,
+                10 * 60,
+                3,
+            )
+            if is_managed_streaming:
+                self.managed_streaming_ingest_client.ingest_from_blob(blob_descriptor, ingestion_properties)
+            else:
+                self.streaming_ingest_client.ingest_from_blob(blob_descriptor, ingestion_properties)
+
+        await self.assert_rows_added(2, timeout=120)


### PR DESCRIPTION
### Changed
- [BREAKING] Aligned the Connection String Builder keywords with the rest of the SDKs.
  This means that some keywords were removed, and they will no longer be parsed as part of the Connection String.  
  Building the Connection String using the builder method will still work as expected.  
  The following keywords have been removed:
    - `msi_auth` / `msi_authentication`
    - `msi_params` / `msi_type`
    - `interactive_login`
    - `az_cli`