### PR TITLE
Bump version to 6.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.4] - 2026-05-06
+
+### Changed
+- Bumped dependencies: azure-identity ≥ 1.25.3 and msal ≥ 1.35.1 for sovereign cloud support.
+
 ## [6.0.3] - 2026-03-31
 
 ### Fixed

--- a/azure-kusto-data/pyproject.toml
+++ b/azure-kusto-data/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "azure-kusto-data"
-version = "6.0.3"
+version = "6.0.4"
 description = "Kusto Data Client"
 authors = [
     { name = "Microsoft Corporation", email = "kustalk@microsoft.com" },

--- a/azure-kusto-ingest/pyproject.toml
+++ b/azure-kusto-ingest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "azure-kusto-ingest"
-version = "6.0.3"
+version = "6.0.4"
 description = "Kusto Ingest Client"
 authors = [
     { name = "Microsoft Corporation", email = "kustalk@microsoft.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "azure-kusto-python"
-version = "6.0.3"
+version = "6.0.4"
 description = "Microsoft Azure Kusto Python SDK"
 dependencies = [
     "azure-kusto-data",

--- a/quick-start/pyproject.toml
+++ b/quick-start/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quick-start"
-version = "6.0.3"
+version = "6.0.4"
 description = "Microsoft Azure Kusto Python SDK"
 dependencies = [
     "azure-kusto-data",


### PR DESCRIPTION
## Changes

- Bumped version 6.0.3 → 6.0.4 in all pyproject.toml files
- Added CHANGELOG.md entry: azure-identity ≥ 1.25.3 and msal ≥ 1.35.1 for sovereign cloud support